### PR TITLE
chore: add pre-commit for buildifier/prettier

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -17,50 +17,50 @@ jobs:
           - 11.2.2
           - 11.6.2
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - uses: bazelbuild/setup-bazelisk@v2
-    - name: Mount bazel cache
-      if: ${{ !startsWith(matrix.os, 'windows') }}
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/bazel
-        key: bazel-${{ matrix.os }}-cuda-${{ matrix.cuda-version }}-${{ hashFiles('.bazelversion') }}
+      - uses: bazelbuild/setup-bazelisk@v2
+      - name: Mount bazel cache
+        if: ${{ !startsWith(matrix.os, 'windows') }}
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/bazel
+          key: bazel-${{ matrix.os }}-cuda-${{ matrix.cuda-version }}-${{ hashFiles('.bazelversion') }}
 
-    - name: Install CUDA (Linux)
-      uses: Jimver/cuda-toolkit@v0.2.8
-      if: ${{ !startsWith(matrix.os, 'windows') }}
-      with:
-        cuda: ${{ matrix.cuda-version }}
-        sub-packages: '["nvcc", "cudart-dev"]'
-        method: network
-    - name: Show bin, include, lib (Linux)
-      if: ${{ !startsWith(matrix.os, 'windows') }}
-      run: |
-        tree ${CUDA_PATH}/bin
-        tree ${CUDA_PATH}/include
-        tree ${CUDA_PATH}/lib64
+      - name: Install CUDA (Linux)
+        uses: Jimver/cuda-toolkit@v0.2.8
+        if: ${{ !startsWith(matrix.os, 'windows') }}
+        with:
+          cuda: ${{ matrix.cuda-version }}
+          sub-packages: '["nvcc", "cudart-dev"]'
+          method: network
+      - name: Show bin, include, lib (Linux)
+        if: ${{ !startsWith(matrix.os, 'windows') }}
+        run: |
+          tree ${CUDA_PATH}/bin
+          tree ${CUDA_PATH}/include
+          tree ${CUDA_PATH}/lib64
 
-    - name: Install CUDA (Windows)
-      uses: Jimver/cuda-toolkit@v0.2.8
-      if: ${{ startsWith(matrix.os, 'windows') }}
-      with:
-        cuda: ${{ matrix.cuda-version }}
-        sub-packages: '["nvcc", "cudart"]'
-        method: network
-    - name: Show bin, include, lib64 (Windows)
-      if: ${{ startsWith(matrix.os, 'windows') }}
-      run: |
-        tree /F $env:CUDA_PATH/bin
-        tree /F $env:CUDA_PATH/include
-        tree /F $env:CUDA_PATH/lib/x64
-    - name: Set Visual Studio Environment (Windows)
-      if: ${{ startsWith(matrix.os, 'windows') }}
-      run: .github/workflows/Set-VSEnv.ps1 2019
+      - name: Install CUDA (Windows)
+        uses: Jimver/cuda-toolkit@v0.2.8
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        with:
+          cuda: ${{ matrix.cuda-version }}
+          sub-packages: '["nvcc", "cudart"]'
+          method: network
+      - name: Show bin, include, lib64 (Windows)
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: |
+          tree /F $env:CUDA_PATH/bin
+          tree /F $env:CUDA_PATH/include
+          tree /F $env:CUDA_PATH/lib/x64
+      - name: Set Visual Studio Environment (Windows)
+        if: ${{ startsWith(matrix.os, 'windows') }}
+        run: .github/workflows/Set-VSEnv.ps1 2019
 
-    - run: bazelisk build //examples/basic:main
-    - run: bazelisk build //examples/rdc:main
-    - run: bazelisk build //examples/if_cuda:main
-    - run: bazelisk build //examples/if_cuda:main --enable_cuda=False
+      - run: bazelisk build //examples/basic:main
+      - run: bazelisk build //examples/rdc:main
+      - run: bazelisk build //examples/if_cuda:main
+      - run: bazelisk build //examples/if_cuda:main --enable_cuda=False
 
-    - run: bazelisk shutdown
+      - run: bazelisk shutdown

--- a/.github/workflows/utilities-tests.yaml
+++ b/.github/workflows/utilities-tests.yaml
@@ -18,22 +18,22 @@ jobs:
     env:
       USE_BAZEL_VERSION: ${{ matrix.bazel-version }}
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - uses: bazelbuild/setup-bazelisk@v2
-    - name: Mount bazel cache
-      if: ${{ !startsWith(matrix.os, 'windows') }}
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/bazel
-        key: bazel-${{ matrix.os }}-${{ matrix.bazel-version }}
+      - uses: bazelbuild/setup-bazelisk@v2
+      - name: Mount bazel cache
+        if: ${{ !startsWith(matrix.os, 'windows') }}
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/bazel
+          key: bazel-${{ matrix.os }}-${{ matrix.bazel-version }}
 
-    - uses: Jimver/cuda-toolkit@v0.2.8
-      with:
-        cuda: 11.6.2
-        sub-packages: '["cudart"]'
-        method: network
+      - uses: Jimver/cuda-toolkit@v0.2.8
+        with:
+          cuda: 11.6.2
+          sub-packages: '["cudart"]'
+          method: network
 
-    - run: bazelisk test -- //tests/...
+      - run: bazelisk test -- //tests/...
 
-    - run: bazelisk shutdown
+      - run: bazelisk shutdown

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+# See CONTRIBUTING.md for instructions.
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+
+# Commitizen runs in commit-msg stage
+# but we don't want to run the other hooks on commit messages
+default_stages: [commit]
+
+repos:
+  # Check formatting and lint for starlark code
+  - repo: https://github.com/keith/pre-commit-buildifier
+    rev: 4.0.1.1
+    hooks:
+      - id: buildifier
+      # - id: buildifier-lint
+  # Enforce that commit messages allow for later changelog generation
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v2.18.0
+    hooks:
+      # Requires that commitizen is already installed
+      - id: commitizen
+        stages: [commit-msg]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v2.4.0"
+    hooks:
+      - id: prettier

--- a/README.md
+++ b/README.md
@@ -46,23 +46,27 @@ determains how the toolchains are detected.
 
 - `cuda_library`: Can be used to compile and create static library for CUDA kernel code. The resulting targets can be
   consumed by [C/C++ Rules](https://bazel.build/reference/be/c-cpp#rules).
-- `cuda_objects`: If you don't understand what *device link* means, you must never use it. This rule produce incomplete
+- `cuda_objects`: If you don't understand what _device link_ means, you must never use it. This rule produce incomplete
   object files that can only be consumed by `cuda_library`. It is created for relocatable device code and device link
   time optimization source files.
 
 ### Flags
 
 Some flags are defined in [cuda/BUILD.bazel](cuda/BUILD.bazel). To use them, for example:
+
 ```
 bazel build --@rules_cuda//cuda:archs=compute_61:compute_61,sm_61
 ```
 
 In `.bazelrc` file, you can define shortcut alias for the flag, for example:
+
 ```
 # Convenient flag shortcuts.
 build --flag_alias=cuda_archs=@rules_cuda//cuda:archs
 ```
+
 and then you can use it as following:
+
 ```
 bazel build --cuda_archs=compute_61:compute_61,sm_61
 ```
@@ -92,6 +96,7 @@ bazel build --cuda_archs=compute_61:compute_61,sm_61
 ## Known issue
 
 Sometimes the following error occurs:
+
 ```
 cc1plus: fatal error: /tmp/tmpxft_00000002_00000019-2.cpp: No such file or directory
 ```
@@ -99,6 +104,7 @@ cc1plus: fatal error: /tmp/tmpxft_00000002_00000019-2.cpp: No such file or direc
 The problem is caused by nvcc use PID to determine temporary file name, and with `--spawn_strategy linux-sandbox` which is the default strategy on Linux, the PIDs nvcc sees are all very small numbers, say 2~4 due to sanboxing. `linux-sandbox` is not hermetic because [it mount root into the sandbox](https://docs.bazel.build/versions/main/command-line-reference.html#flag--experimental_use_hermetic_linux_sandbox), thus, `/tmp` is shared between sandboxes, which is causing name conflict under high parallelism. Similar problem has been reported at [nvidia forums](https://forums.developer.nvidia.com/t/avoid-generating-temp-files-in-tmp-while-nvcc-compiling/197657/10).
 
 To avoid it:
-  - Use `--spawn_strategy local` should eliminate the case because it will let nvcc sees the true PIDs.
-  - Use `--experimental_use_hermetic_linux_sandbox` should eliminate the case because it will avoid the sharing of `/tmp`.
-  - Add `-objtemp` option to the command should reduce the case from happening.
+
+- Use `--spawn_strategy local` should eliminate the case because it will let nvcc sees the true PIDs.
+- Use `--experimental_use_hermetic_linux_sandbox` should eliminate the case because it will avoid the sharing of `/tmp`.
+- Add `-objtemp` option to the command should reduce the case from happening.

--- a/cuda/private/BUILD.bazel
+++ b/cuda/private/BUILD.bazel
@@ -7,8 +7,8 @@ bzl_library(
     srcs = glob(["**/*.bzl"]),
     visibility = ["//visibility:public"],
     deps = [
-        "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:partial",
+        "@bazel_skylib//lib:paths",
         "@bazel_skylib//lib:unittest",
         "@bazel_skylib//rules:common_settings",
         "@bazel_tools//tools/build_defs/repo:http.bzl",

--- a/cuda/private/cuda_helper.bzl
+++ b/cuda/private/cuda_helper.bzl
@@ -450,7 +450,7 @@ def _get_all_requested_features(ctx, cuda_toolchain, requested_features):
     all_features = []
     compilation_mode = ctx.var.get("COMPILATION_MODE", None)
     if compilation_mode == None:
-        print("unknown COMPILATION_MODE, use opt")
+        print("unknown COMPILATION_MODE, use opt")  # buildifier: disable=print
         compilation_mode = "opt"
     all_features.append(compilation_mode)
 

--- a/cuda/private/providers.bzl
+++ b/cuda/private/providers.bzl
@@ -17,7 +17,7 @@ cuda_archs = [
     "80",
     "86",
     "87",
-    "90"
+    "90",
 ]
 
 Stage2ArchInfo = provider(

--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -32,8 +32,8 @@ def _get_nvcc_version(repository_ctx, cuda_path):
     result = repository_ctx.execute([cuda_path + "/bin/nvcc", "--version"])
     if result.return_code != 0:
         return [-1, -1]
-    for l in [l for l in result.stdout.split("\n") if ", release " in l]:
-        segments = l.split(", release ")
+    for line in [line for line in result.stdout.split("\n") if ", release " in line]:
+        segments = line.split(", release ")
         if len(segments) != 2:
             continue
         version = [int(v) for v in segments[-1].split(", ")[0].split(".")]
@@ -109,6 +109,7 @@ def config_cuda_toolkit_and_nvcc(repository_ctx, cuda):
         repository_ctx: repository_ctx
         cuda: The struct returned from detect_cuda_toolkit
     """
+
     # Generate @local_cuda//BUILD and @local_cuda//defs.bzl
     defs_bzl_content = defs_bzl_shared
     defs_if_local_cuda = "def if_local_cuda(if_true, if_false = []):\n    return %s\n"

--- a/cuda/private/toolchain_config_lib.bzl
+++ b/cuda/private/toolchain_config_lib.bzl
@@ -444,7 +444,7 @@ def _is_satisfied(info, name):
                 implies_met,
                 requires_met,
             ),
-        )
+        )  # buildifier: disable=print
     return satisfied
 
 def _check_activatable(info, to_check):
@@ -603,7 +603,7 @@ def _configure_features(
     _disable_unsupported_activatables(info)
     _check_provides_conflict(info)
     if info._debug:
-        print("Enabled features after configuration:", _get_enabled_feature(info))
+        print("Enabled features after configuration:", _get_enabled_feature(info))  # buildifier: disable=print
     return info
 
 def _get_default_features_and_action_configs(info):

--- a/cuda/private/toolchain_configs/clang.bzl
+++ b/cuda/private/toolchain_configs/clang.bzl
@@ -4,7 +4,6 @@ load("//cuda/private:action_names.bzl", "ACTION_NAMES")
 load("//cuda/private:artifact_categories.bzl", "ARTIFACT_CATEGORIES")
 load("//cuda/private:providers.bzl", "CudaToolchainConfigInfo", "CudaToolkitInfo")
 load("//cuda/private:toolchain.bzl", "use_cpp_toolchain")
-load("//cuda/private:toolchain_configs/utils.bzl", "nvcc_version_ge")
 load(
     "//cuda/private:toolchain_config_lib.bzl",
     "action_config",
@@ -12,10 +11,8 @@ load(
     "env_entry",
     "env_set",
     "feature",
-    "feature_set",
     "flag_group",
     "flag_set",
-    "tool",
     "with_feature_set",
 )
 

--- a/cuda/private/toolchain_configs/nvcc.bzl
+++ b/cuda/private/toolchain_configs/nvcc.bzl
@@ -4,7 +4,6 @@ load("//cuda/private:action_names.bzl", "ACTION_NAMES")
 load("//cuda/private:artifact_categories.bzl", "ARTIFACT_CATEGORIES")
 load("//cuda/private:providers.bzl", "CudaToolchainConfigInfo", "CudaToolkitInfo")
 load("//cuda/private:toolchain.bzl", "use_cpp_toolchain")
-load("//cuda/private:toolchain_configs/utils.bzl", "nvcc_version_ge")
 load(
     "//cuda/private:toolchain_config_lib.bzl",
     "action_config",
@@ -428,8 +427,8 @@ cuda_toolchain_config = rule(
     attrs = {
         "cuda_toolkit": attr.label(mandatory = True, providers = [CudaToolkitInfo], doc = "A target that provides a `CudaToolkitInfo`."),
         "toolchain_identifier": attr.string(values = ["nvcc"], mandatory = True),
-        "nvcc_version_major": attr.int(doc="The CUDA Toolkit major version, e.g, 11 for 11.6"),
-        "nvcc_version_minor": attr.int(doc="The CUDA Toolkit minor version, e.g, 6 for 11.6"),
+        "nvcc_version_major": attr.int(doc = "The CUDA Toolkit major version, e.g, 11 for 11.6"),
+        "nvcc_version_minor": attr.int(doc = "The CUDA Toolkit minor version, e.g, 6 for 11.6"),
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),  # legacy behaviour
     },
     provides = [CudaToolchainConfigInfo],

--- a/cuda/private/toolchain_configs/nvcc_msvc.bzl
+++ b/cuda/private/toolchain_configs/nvcc_msvc.bzl
@@ -517,9 +517,9 @@ cuda_toolchain_config = rule(
     attrs = {
         "cuda_toolkit": attr.label(mandatory = True, providers = [CudaToolkitInfo], doc = "A target that provides a `CudaToolkitInfo`."),
         "toolchain_identifier": attr.string(values = ["nvcc"], mandatory = True),
-        "nvcc_version_major": attr.int(doc="The CUDA Toolkit major version, e.g, 11 for 11.6"),
-        "nvcc_version_minor": attr.int(doc="The CUDA Toolkit minor version, e.g, 6 for 11.6"),
-        "msvc_env_tmp": attr.string(doc="The TEMP directory."),
+        "nvcc_version_major": attr.int(doc = "The CUDA Toolkit major version, e.g, 11 for 11.6"),
+        "nvcc_version_minor": attr.int(doc = "The CUDA Toolkit minor version, e.g, 6 for 11.6"),
+        "msvc_env_tmp": attr.string(doc = "The TEMP directory."),
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),  # legacy behaviour
     },
     provides = [CudaToolchainConfigInfo],

--- a/examples/rdc/BUILD.bazel
+++ b/examples/rdc/BUILD.bazel
@@ -1,9 +1,9 @@
-load("//cuda:defs.bzl", "cuda_objects", "cuda_library")
+load("//cuda:defs.bzl", "cuda_library", "cuda_objects")
 
 cuda_objects(
     name = "a",
     srcs = ["a.cu"],
-    deps = [":b"]
+    deps = [":b"],
 )
 
 cuda_objects(
@@ -14,11 +14,11 @@ cuda_objects(
 
 cuda_library(
     name = "librdc",
+    rdc = 1,
     deps = [
         ":a",
         ":b",
     ],
-    rdc = 1,
 )
 
 cc_binary(

--- a/tests/flag/BUILD.bazel
+++ b/tests/flag/BUILD.bazel
@@ -14,7 +14,6 @@ load(
     "num_actions_test",
 )
 load("@rules_cuda//cuda:defs.bzl", "cuda_library")
-load("@local_cuda//:defs.bzl", "if_linux", "if_windows")
 
 num_actions_test(
     name = "cuda_library_num_actions_test",

--- a/tests/flag/flag_validation_test.bzl
+++ b/tests/flag/flag_validation_test.bzl
@@ -1,6 +1,4 @@
-load("@bazel_skylib//lib:partial.bzl", "partial")
-load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
-load("//cuda/private:cuda_helper.bzl", "cuda_helper")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 
 def _num_actions_test_impl(ctx):
     env = analysistest.begin(ctx)

--- a/tests/toolchain_config_lib/toolchain_config_lib_test.bzl
+++ b/tests/toolchain_config_lib/toolchain_config_lib_test.bzl
@@ -1,8 +1,6 @@
-load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts", "unittest")
 load("//cuda/private:providers.bzl", "CudaToolchainConfigInfo")
-load("//cuda/private:toolchain_config_lib.bzl", "action_config", "env_entry", "env_set", "feature", "feature_set", "flag_group", "flag_set", "tool", "variable_with_value", "with_feature_set")
-load("//cuda/private:toolchain_config_lib.bzl", "access", "config_helper", "create_var_from_value", "eval_feature", "eval_flag_group", "exist", "expand_flag", "parse_flag")
+load("//cuda/private:toolchain_config_lib.bzl", "access", "action_config", "config_helper", "create_var_from_value", "env_entry", "env_set", "eval_feature", "eval_flag_group", "exist", "expand_flag", "feature", "feature_set", "flag_group", "flag_set", "parse_flag", "tool", "variable_with_value", "with_feature_set")
 
 def _expect_failure_msg(ctx):
     env = analysistest.begin(ctx)


### PR DESCRIPTION
This adds a pre-commit file and adjusts many files to pass buildifier/prettier. buildifier-lint is currently disabled due to a number of linting failures related to documentation that will need to be fixed.