### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cloudhan @jsharpe @ryanleary


### PR DESCRIPTION
As per guidelines for bazel-contrib repositories add a CODEOWNERS file.