### PR TITLE
Default cuda to on

### DIFF
--- a/cuda/BUILD.bazel
+++ b/cuda/BUILD.bazel
@@ -23,7 +23,7 @@ toolchain_type(name = "toolchain_type")
 # Set with --@rules_cuda//cuda:enable
 bool_flag(
     name = "enable",
-    build_setting_default = False,
+    build_setting_default = True,
 )
 
 # This config setting can be used for conditionally depend on cuda.


### PR DESCRIPTION
The rules should ideally work with no bazel flags. Having an extra opt-in step by default will likely confuse new users as to why cuda isn't building if the config flag isn't set to enable the rules.