### PR TITLE
Set local and configure on local_cuda repository

### DIFF
--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -184,6 +184,8 @@ def _local_cuda_impl(repository_ctx):
 
 _local_cuda = repository_rule(
     implementation = _local_cuda_impl,
+    configure = True,
+    local = True,
     environ = ["CUDA_PATH", "PATH", "CUDA_CLANG_PATH", "BAZEL_LLVM"],
     # remotable = True,
 )


### PR DESCRIPTION
Tell bazel that the configuration is inspecting the local system and drawing from local installed files for the cuda toolchain.