### PR TITLE
Add thrust and cub repos

### DIFF
--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -210,4 +210,22 @@ def rules_cuda_dependencies():
         ],
     )
 
+    maybe(
+        name = "thrust",
+        repo_rule = http_archive,
+        build_file = "@rules_cuda//third_party:thrust.BUILD",
+        sha256 = "d021e37f5aac30fd1b9737865399feb57db8e601ae2fc0af3cd41784435e9523",
+        strip_prefix = "thrust-1.17.2",
+        urls = ["https://github.com/NVIDIA/thrust/archive/refs/tags/1.17.2.tar.gz"],
+    )
+
+    maybe(
+        name = "cub",
+        repo_rule = http_archive,
+        build_file = "@rules_cuda//third_party:cub.BUILD",
+        sha256 = "1013a595794548c359f22c07e1f8c620b97e3a577f7e8496d9407f74566a3e2a",
+        strip_prefix = "cub-1.17.2",
+        urls = ["https://github.com/NVIDIA/cub/archive/refs/tags/1.17.2.tar.gz"],
+    )
+
     _local_cuda(name = "local_cuda")

--- a/examples/thrust/BUILD.bazel
+++ b/examples/thrust/BUILD.bazel
@@ -5,7 +5,7 @@ load("//cuda:defs.bzl", "cuda_library")
 cuda_library(
     name = "thrust_cu",
     srcs = ["thrust.cu"],
-    deps = ["@local_cuda//:thrust"],
+    deps = ["@thrust"],
 )
 
 # Run with 'bazel run //examples/thrust:main'

--- a/third_party/cub.BUILD
+++ b/third_party/cub.BUILD
@@ -1,15 +1,15 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@rules_license//rules:license.bzl", "license")
+#load("@rules_license//rules:license.bzl", "license")
 
-package(default_applicable_licenses = [":license"])
+#package(default_applicable_licenses = [":license"])
 
-license(
-    name = "license",
-    license_kinds = [
-        "@rules_license//licenses/spdx:BSD-3-Clause",
-    ],
-    license_text = "LICENSE.TXT",
-)
+#license(
+#    name = "license",
+#    license_kinds = [
+#        "@rules_license//licenses/spdx:BSD-3-Clause",
+#    ],
+#    license_text = "LICENSE.TXT",
+#)
 
 filegroup(
     name = "include-src",

--- a/third_party/cub.BUILD
+++ b/third_party/cub.BUILD
@@ -1,0 +1,45 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+
+package(default_applicable_licenses = [":license"])
+
+license(
+    name = "license",
+    license_kinds = [
+        "@rules_license//licenses/spdx:BSD-3-Clause",
+    ],
+    license_text = "LICENSE.TXT",
+)
+
+filegroup(
+    name = "include-src",
+    srcs = glob([
+        "cub/*.h",
+    ]),
+)
+
+cc_library(
+    name = "includes",
+    hdrs = [":include-src"],
+    includes = ["."],
+    textual_hdrs = glob([
+        "cub/*.cuh",
+        "cub/agent/*.cuh",
+        "cub/block/*.cuh",
+        "cub/block/specializations/*.cuh",
+        "cub/device/*.cuh",
+        "cub/device/dispatch/*.cuh",
+        "cub/grid/*.cuh",
+        "cub/warp/*.cuh",
+        "cub/warp/specializations/*.cuh",
+        "cub/iterator/*.cuh",
+        "cub/thread/*.cuh",
+        "cub/detail/*.cuh",
+    ]),
+)
+
+cc_library(
+    name = "cub",
+    visibility = ["//visibility:public"],
+    deps = [":includes"],
+)

--- a/third_party/thrust.BUILD
+++ b/third_party/thrust.BUILD
@@ -1,0 +1,37 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@rules_license//rules:license.bzl", "license")
+
+package(default_applicable_licenses = [":license"])
+
+license(
+    name = "license",
+    license_kinds = [
+        "@rules_license//licenses/spdx:Apache-2.0",
+        "@rules_license//licenses/spdx:BSL-1.0",
+    ],
+    license_text = "LICENSE",
+)
+
+filegroup(
+    name = "include-src",
+    srcs = glob([
+        "thrust/*.h",
+        "thrust/**/*.h",
+        "thrust/**/*.inl",
+    ]),
+)
+
+cc_library(
+    name = "includes",
+    hdrs = [":include-src"],
+    includes = ["."],
+)
+
+cc_library(
+    name = "thrust",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":includes",
+        "@cub",
+    ],
+)

--- a/third_party/thrust.BUILD
+++ b/third_party/thrust.BUILD
@@ -1,16 +1,16 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
-load("@rules_license//rules:license.bzl", "license")
+#load("@rules_license//rules:license.bzl", "license")
 
-package(default_applicable_licenses = [":license"])
+#package(default_applicable_licenses = [":license"])
 
-license(
-    name = "license",
-    license_kinds = [
-        "@rules_license//licenses/spdx:Apache-2.0",
-        "@rules_license//licenses/spdx:BSL-1.0",
-    ],
-    license_text = "LICENSE",
-)
+#license(
+#    name = "license",
+#    license_kinds = [
+#        "@rules_license//licenses/spdx:Apache-2.0",
+#        "@rules_license//licenses/spdx:BSL-1.0",
+#    ],
+#    license_text = "LICENSE",
+#)
 
 filegroup(
     name = "include-src",


### PR DESCRIPTION
As thrust can also be used via an OpenMP backend, make this available as repository outside of the toolchain.
