### PR TITLE
Make CI eco-friendly by avoiding run pipelines twice on push within PR

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -2,6 +2,8 @@ name: Test Example Build
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/docs-tests.yaml
+++ b/.github/workflows/docs-tests.yaml
@@ -2,6 +2,8 @@ name: Test Generating Docs
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/utilities-tests.yaml
+++ b/.github/workflows/utilities-tests.yaml
@@ -1,7 +1,9 @@
 name: Test Utilities
 
-on: 
+on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Avoid the wasting of public CI resource and make it a little bit eco-friendlier.