### PR TITLE
Enable rules_cuda by default, add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ bazel build --cuda_archs=compute_61:compute_61,sm_61
 - `@rules_cuda//cuda:enable`
 
   Enable or disable all rules_cuda related rules. When disabled, the detected cuda toolchains will also be disabled to avoid potential human error.
+  By default, rules_cuda rules are enabled. See `examples/if_cuda` for how to support both cuda-enabled and cuda-free builds.
 
 - `@rules_cuda//cuda:archs`
 

--- a/cuda/BUILD.bazel
+++ b/cuda/BUILD.bazel
@@ -23,7 +23,7 @@ toolchain_type(name = "toolchain_type")
 # Set with --@rules_cuda//cuda:enable
 bool_flag(
     name = "enable",
-    build_setting_default = False,
+    build_setting_default = True,
 )
 
 # This config setting can be used for conditionally depend on cuda.

--- a/examples/if_cuda/BUILD.bazel
+++ b/examples/if_cuda/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@rules_cuda//cuda:defs.bzl", "cuda_library")
-load(":if_cuda.bzl", "if_cuda")
 
 cuda_library(
     name = "kernel",
@@ -10,9 +9,12 @@ cuda_library(
 cc_binary(
     name = "main",
     srcs = ["main.cpp"],
-    defines = if_cuda(
-        ["CUDA_ENABLED"],
-        if_false = ["CUDA_NOT_ENABLED"],
-    ),
-    deps = if_cuda([":kernel"]),
+    defines = [] + select({
+        "@rules_cuda//cuda:is_enabled": ["CUDA_ENABLED"],
+        "//conditions:default": ["CUDA_DISABLED"]
+    }),
+    deps = [] + select({
+        "@rules_cuda//cuda:is_enabled": [":kernel"],
+        "//conditions:default": []
+    })
 )

--- a/examples/if_cuda/README.md
+++ b/examples/if_cuda/README.md
@@ -1,0 +1,81 @@
+# if_cuda Example
+
+This example demonstrates how to conditionally include CUDA targets in your build.
+
+By default, _rules_cuda_ rules are enabled. Disabling rules_cuda rules can be accomplished by passing the `@rules_cuda//cuda:enable`
+flag at the command-line or via `.bazelrc`. 
+
+## Building Example with rules_cuda
+
+From the `examples` directory, build the sample application:
+
+```bash
+bazel build //if_cuda:main
+```
+
+And run the binary:
+```bash
+./bazel-bin/if_cuda/main
+```
+
+If a valid GPU device is running on your development machine, the application will exit successfully and print:
+```
+cuda enabled
+```
+
+If running without a valid GPU device, the code, as written, will print a CUDA error and exit:
+```
+CUDA_VISIBLE_DEVICES=-1 ./bazel-bin/if_cuda/main
+CUDA Error Code  : 100
+     Error String: no CUDA-capable device is detected
+```
+
+## Building Example without rules_cuda
+
+To build the binary without CUDA support, disable rules_cuda:
+
+```bash
+bazel build //if_cuda:main --@rules_cuda//cuda:enable`
+```
+
+And run the binary:
+```bash
+./bazel-bin/if_cuda/main
+```
+
+The binary will output:
+```
+cuda disabled
+```
+
+### rules_cuda targets
+
+Any attempt to build a rules_cuda-defined rule (e.g. `cuda_library` or `cuda_objects`) will _FAIL_ if rules_cuda is disabled, as the CUDA toolchain will not be registered for that invocation.
+
+```
+bazel build //if_cuda:kernel --@rules_cuda//cuda:enable=false
+ERROR: /home/ryan/devel/rules_cuda/examples/if_cuda/BUILD.bazel:3:13: While resolving toolchains for target //if_cuda:kernel: No matching toolchains found for types @rules_cuda//cuda:toolchain_type.
+To debug, rerun with --toolchain_resolution_debug='@rules_cuda//cuda:toolchain_type'
+If platforms or toolchains are a new concept for you, we'd encourage reading https://bazel.build/concepts/platforms-intro.
+ERROR: Analysis of target '//if_cuda:kernel' failed; build aborted:
+FAILED: Build did NOT complete successfully (0 packages loaded, 133 targets configured)
+```
+
+## Developing for CUDA- and CUDA-free targets
+
+Note the `BUILD.bazel` file takes care to ensure that
+- CUDA-related dependencies are excluded when CUDA is disabled
+- Preprocessor variables are set to enable compile-time differentiated codepaths between CUDA and non-CUDA builds
+
+Our example build (when CUDA is enabled) sets a `CUDA_ENABLED` preprocessor variable. This variable is then checked in `main.cpp` to determine
+the type of compilation underway. You are free to set any set of preprocessor variables as needed by your particular project. Checking whether
+rules_cuda or not can be achieved simply by using Bazel's `select` feature:
+
+```
+select({
+        "@rules_cuda//cuda:is_enabled": [], # add whatever settings are required if using CUDA
+        "//conditions:default": [] # add whatever settings are required if not using CUDA
+    })
+```
+
+We use this same mechanism to include the `cuda_library` dependencies.

--- a/examples/if_cuda/if_cuda.bzl
+++ b/examples/if_cuda/if_cuda.bzl
@@ -1,5 +1,0 @@
-def if_cuda(if_true, if_false = []):
-    return select({
-        "@rules_cuda//cuda:is_enabled": if_true,
-        "//conditions:default": if_false,
-    })

--- a/examples/if_cuda/main.cpp
+++ b/examples/if_cuda/main.cpp
@@ -12,7 +12,7 @@ int main() {
 #if defined(CUDA_ENABLED)
   launch();
   return 0;
-#elif defined(CUDA_NOT_ENABLED)
+#elif defined(CUDA_DISABLED)
   do_something_else();
   return -1;
 #else


### PR DESCRIPTION
Follows #31 with minor changes to the `if_cuda` and expansion of related documentation.