### PR TITLE
Add option to add files to the toolchain configuration

### DIFF
--- a/cuda/private/actions/compile.bzl
+++ b/cuda/private/actions/compile.bzl
@@ -73,7 +73,7 @@ def compile(
             executable = cuda_compiler,
             arguments = [args],
             outputs = [obj_file],
-            inputs = depset([src], transitive = [common.headers, cc_toolchain.all_files]),
+            inputs = depset([src], transitive = [common.headers, cc_toolchain.all_files, cuda_toolchain.all_files]),
             env = env,
             mnemonic = "CudaCompile",
             progress_message = "Compiling %s" % src.path,

--- a/cuda/private/actions/dlink.bzl
+++ b/cuda/private/actions/dlink.bzl
@@ -84,7 +84,7 @@ def _compiler_device_link(
         executable = cuda_compiler,
         arguments = [args],
         outputs = [obj_file],
-        inputs = depset(transitive = [objects, cc_toolchain.all_files]),
+        inputs = depset(transitive = [objects, cc_toolchain.all_files, cuda_toolchain.all_files]),
         env = env,
         mnemonic = "CudaDeviceLink",
         progress_message = "Device linking %{output}",

--- a/cuda/private/toolchain.bzl
+++ b/cuda/private/toolchain.bzl
@@ -17,6 +17,7 @@ def _cuda_toolchain_impl(ctx):
         platform_common.ToolchainInfo(
             name = ctx.label.name,
             compiler_executable = ctx.attr.compiler_executable,
+            all_files = ctx.attr.compiler_files.files if ctx.attr.compiler_files else depset(),
             selectables_info = selectables_info,
             artifact_name_patterns = artifact_name_patterns,
             cuda_toolkit = cuda_toolchain_config.cuda_toolkit,
@@ -33,6 +34,7 @@ cuda_toolchain = rule(
             doc = "A target that provides a `CudaToolchainConfigInfo`.",
         ),
         "compiler_executable": attr.string(mandatory = True, doc = "The path of the main executable of this toolchain."),
+        "compiler_files": attr.label(allow_files = True, cfg = "exec", doc = "The set of files that are needed when compiling using this toolchain."),
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
     },
 )


### PR DESCRIPTION
Adds the ability to specify files that are needed by the compiler toolchain which is the first step towards being able to create a hermetic cuda toolchain.