### PR TITLE
Use merge_cc_infos to calculate common flags

### DIFF
--- a/cuda/private/cuda_helper.bzl
+++ b/cuda/private/cuda_helper.bzl
@@ -157,6 +157,7 @@ def _create_common_info(
         host_compile_flags = [],
         host_link_flags = [],
         ptxas_flags = [],
+        transitive_cc_info = None,
         transitive_linking_contexts = []):
     """Constructor of the common object.
 
@@ -193,6 +194,7 @@ def _create_common_info(
         host_compile_flags = host_compile_flags,
         host_link_flags = host_link_flags,
         ptxas_flags = ptxas_flags,
+        transitive_cc_info = transitive_cc_info,
         transitive_linker_inputs = [ctx.linker_inputs for ctx in transitive_linking_contexts],
         transitive_linking_contexts = transitive_linking_contexts,
     )
@@ -204,18 +206,21 @@ def _create_common(ctx):
     """
     attr = ctx.attr
 
+    all_cc_deps = [dep for dep in attr.deps if CcInfo in dep]
+    if hasattr(attr, "_builtin_deps"):
+        all_cc_deps.extend([dep for dep in attr._builtin_deps if CcInfo in dep])
+
+    merged_cc_info = cc_common.merge_cc_infos(cc_infos = [dep[CcInfo] for dep in all_cc_deps])
+
     # gather include info
-    includes = []
+    includes = merged_cc_info.compilation_context.includes.to_list()
     system_includes = []
     quote_includes = []
     quote_includes.extend(_resolve_workspace_root_includes(ctx))
     for inc in attr.includes:
         system_includes.extend(_resolve_includes(ctx, inc))
-    for dep in attr.deps:
-        if CcInfo in dep:
-            includes.extend(dep[CcInfo].compilation_context.includes.to_list())
-            system_includes.extend(dep[CcInfo].compilation_context.system_includes.to_list())
-            quote_includes.extend(dep[CcInfo].compilation_context.quote_includes.to_list())
+    system_includes.extend(merged_cc_info.compilation_context.system_includes.to_list())
+    quote_includes.extend(merged_cc_info.compilation_context.quote_includes.to_list())
 
     # gather header info
     public_headers = []
@@ -226,18 +231,10 @@ def _create_common(ctx):
         hdr = [f for f in fs.files.to_list() if _check_src_extension(f, ALLOW_CUDA_HDRS)]
         private_headers.extend(hdr)
     headers = public_headers + private_headers
-    transitive_headers = []
-    for dep in attr.deps:
-        if CcInfo in dep:
-            transitive_headers.append(dep[CcInfo].compilation_context.headers)
+    transitive_headers = [merged_cc_info.compilation_context.headers]
 
     # gather linker info
-    builtin_linking_contexts = []
-    if hasattr(attr, "_builtin_deps"):
-        builtin_linking_contexts = [dep[CcInfo].linking_context for dep in attr._builtin_deps if CcInfo in dep]
-
-    transitive_linking_contexts = [dep[CcInfo].linking_context for dep in attr.deps if CcInfo in dep]
-    transitive_linking_contexts.extend(builtin_linking_contexts)
+    transitive_linking_contexts = [merged_cc_info.linking_context]
 
     # gather compile info
     defines = []
@@ -255,8 +252,7 @@ def _create_common(ctx):
     for dep in attr.deps:
         if CudaInfo in dep:
             defines.extend(dep[CudaInfo].defines.to_list())
-        if CcInfo in dep:
-            host_defines.extend(dep[CcInfo].compilation_context.defines.to_list())
+    host_defines.extend(merged_cc_info.compilation_context.defines.to_list())
     defines.extend(attr.defines)
     host_defines.extend(attr.host_defines)
 
@@ -278,6 +274,7 @@ def _create_common(ctx):
         host_compile_flags = host_compile_flags,
         host_link_flags = host_link_flags,
         ptxas_flags = ptxas_flags,
+        transitive_cc_info = merged_cc_info,
         transitive_linking_contexts = transitive_linking_contexts,
     )
 

--- a/cuda/private/rules/cuda_library.bzl
+++ b/cuda/private/rules/cuda_library.bzl
@@ -81,6 +81,8 @@ def _cuda_library_impl(ctx):
     libs = [] if lib == None else [lib]
     pic_libs = [] if pic_lib == None else [pic_lib]
 
+    cc_info = cc_common.merge_cc_infos(direct_cc_infos = [CcInfo(compilation_context = compilation_ctx, linking_context = linking_ctx)], cc_infos = [common.transitive_cc_info])
+
     return [
         DefaultInfo(files = depset(libs + pic_libs)),
         OutputGroupInfo(
@@ -90,8 +92,8 @@ def _cuda_library_impl(ctx):
             pic_objects = pic_objects,
         ),
         CcInfo(
-            compilation_context = compilation_ctx,
-            linking_context = linking_ctx,
+            compilation_context = cc_info.compilation_context,
+            linking_context = cc_info.linking_context,
         ),
         cuda_helper.create_cuda_info(defines = depset(common.defines)),
     ]


### PR DESCRIPTION
This fixes a bug where the transitive flags aren't propagated correctly in all cases. Notably adds the _builtin_deps dependency to pick up context from the configured `//cuda:runtime` dependency.