### PR TITLE
Allow inl as header suffix.

### DIFF
--- a/cuda/private/rules/common.bzl
+++ b/cuda/private/rules/common.bzl
@@ -3,6 +3,7 @@ ALLOW_CUDA_HDRS = [
     ".h",
     ".hpp",
     ".hh",
+    ".inl",
 ]
 
 ALLOW_CUDA_SRCS = [


### PR DESCRIPTION
Libraries such as Thrust have .inl files that might exposed in headers. This PR allow that as a valid header name.