### PR TITLE
Add publish-to-bcr configuration

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,3 @@
+fixedReleaser:
+  login: jsharpe
+  email: james.sharpe@zenotech.com

--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,3 +1,0 @@
-fixedReleaser:
-  login: jsharpe
-  email: james.sharpe@zenotech.com

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,13 @@
+{
+  "homepage": "https://github.com/bazel-contrib/rules_cuda",
+  "maintainers": [
+    {
+      "email": "james.sharpe@zenotech.com",
+      "github": "jsharpe",
+      "name": "James Sharpe"
+    }
+  ],
+  "repository": ["github:bazel-contrib/rules_cuda"],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,12 +1,12 @@
 # We recommend included a bcr test workspace that exercises your ruleset with bzlmod.
 # For an example, see https://github.com/aspect-build/bazel-lib/tree/main/e2e/bzlmod.
-bcr_test_module:
-  module_path: "examples"
-  matrix:
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
-  tasks:
-    run_tests:
-      name: "Run test module"
-      platform: ${{ platform }}
-      test_targets:
-        - "//..."
+#bcr_test_module:
+#  module_path: "examples"
+#  matrix:
+#    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+#  tasks:
+#    run_tests:
+#      name: "Run test module"
+#      platform: ${{ platform }}
+#      test_targets:
+#        - "//..."

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,12 @@
+# We recommend included a bcr test workspace that exercises your ruleset with bzlmod.
+# For an example, see https://github.com/aspect-build/bazel-lib/tree/main/e2e/bzlmod.
+bcr_test_module:
+  module_path: "examples"
+  matrix:
+    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      test_targets:
+        - "//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/releases/download/{VERSION}/{REPO}-{TAG}.tar.gz"
+}


### PR DESCRIPTION
Adds configuration for the publish-to-bcr app which auto publishes a PR to the bazel-central-registry whenever a release is made.