### PR TITLE
Add host compiler flag to device link step

### DIFF
--- a/cuda/private/toolchain_configs/nvcc.bzl
+++ b/cuda/private/toolchain_configs/nvcc.bzl
@@ -68,7 +68,10 @@ def _impl(ctx):
         enabled = True,
         flag_sets = [
             flag_set(
-                actions = [ACTION_NAMES.cuda_compile],
+                actions = [
+                    ACTION_NAMES.cuda_compile,
+                    ACTION_NAMES.device_link,
+                ],
                 flag_groups = [flag_group(flags = ["-ccbin", "%{host_compiler}"])],
             ),
         ],


### PR DESCRIPTION
As is, nvlink will use the system compiler configuration to produce objects, resulting in an error when building //rules_cuda/examples/rdc:main  in 2 cases:
* When using a custom gcc toolchain that is a different version than your system install, nvcc will fail to find gcc after nvlink-ing
* When cross-compiling, nvlink will produce objects for the host architecture instead of the target architecture

This change is also likely needed in nvcc_msvc.bzl, but I have no way to test.