### PR TITLE
Various fixes to get rules_cuda to work with Lambda-stack

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ !startsWith(matrix.cases.os, 'windows') && matrix.cases.source == 'ubuntu' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y nvidia-cuda-dev=${{ matrix.cases.cuda-version }}
+          sudo apt-get install -y nvidia-cuda-dev=${{ matrix.cases.cuda-version }} nvidia-cuda-toolkit=${{ matrix.cases.cuda-version }}
 
       - name: Install CUDA (Windows)
         uses: Jimver/cuda-toolkit@v0.2.10

--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -17,7 +17,7 @@ jobs:
           - { os: "ubuntu-18.04", cuda-version: "10.1.243", source: "nvidia" }
           - { os: "ubuntu-18.04", cuda-version: "11.2.2", source: "nvidia" }
           - { os: "ubuntu-20.04", cuda-version: "11.6.2", source: "nvidia" }
-          # - { os: "ubuntu-22.04", cuda-version: "11.5.1-1ubuntu1", source: "ubuntu" }
+          - { os: "ubuntu-22.04", cuda-version: "11.5.1-1ubuntu1", source: "ubuntu" }
           - { os: "windows-2019", cuda-version: "10.1.243", source: "nvidia" }
           - { os: "windows-2019", cuda-version: "11.6.2", source: "nvidia" }
     steps:

--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -51,6 +51,8 @@ jobs:
           sudo apt-get install -y nvidia-cuda-dev=${{ matrix.cases.cuda-version }} nvidia-cuda-toolkit=${{ matrix.cases.cuda-version }} gcc-9 g++-9
           export CC=gcc-9
           export CXX=g++-9
+          echo "CC=gcc-9" >> $GITHUB_ENV
+          echo "CXX=g++-9" >> $GITHUB_ENV
 
       - name: Install CUDA (Windows)
         uses: Jimver/cuda-toolkit@v0.2.10

--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -48,7 +48,9 @@ jobs:
         if: ${{ !startsWith(matrix.cases.os, 'windows') && matrix.cases.source == 'ubuntu' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y nvidia-cuda-dev=${{ matrix.cases.cuda-version }} nvidia-cuda-toolkit=${{ matrix.cases.cuda-version }}
+          sudo apt-get install -y nvidia-cuda-dev=${{ matrix.cases.cuda-version }} nvidia-cuda-toolkit=${{ matrix.cases.cuda-version }} gcc-9 g++-9
+          export CC=gcc-9
+          export CXX=g++-9
 
       - name: Install CUDA (Windows)
         uses: Jimver/cuda-toolkit@v0.2.10

--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -102,7 +102,7 @@ def config_cuda_toolkit_and_nvcc(repository_ctx, cuda):
         if repository_ctx.path(cuda.path).get_child('lib', 'x86_64-linux-gnu').exists:
             repository_ctx.symlink(cuda.path + '/lib/x86_64-linux-gnu', "cuda/lib64")
         else:
-            repository_ctx.symlink(cuda.path + '/lib64', "cuda/bin")
+            repository_ctx.symlink(cuda.path + '/lib64', "cuda/lib64")
         repository_ctx.symlink(Label("//cuda:runtime/BUILD.local_cuda"), "BUILD")
         defs_bzl_content += defs_if_local_cuda % "if_true"
     else:

--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -98,7 +98,11 @@ def config_cuda_toolkit_and_nvcc(repository_ctx, cuda):
     defs_bzl_content = ""
     defs_if_local_cuda = "def if_local_cuda(if_true, if_false = []):\n    return %s\n"
     if cuda.path != None:
-        repository_ctx.symlink(cuda.path, "cuda")
+        repository_ctx.symlink(cuda.path + '/bin', "cuda/bin")
+        if repository_ctx.path(cuda.path).get_child('lib', 'x86_64-linux-gnu').exists:
+            repository_ctx.symlink(cuda.path + '/lib/x86_64-linux-gnu', "cuda/lib64")
+        else:
+            repository_ctx.symlink(cuda.path + '/lib64', "cuda/bin")
         repository_ctx.symlink(Label("//cuda:runtime/BUILD.local_cuda"), "BUILD")
         defs_bzl_content += defs_if_local_cuda % "if_true"
     else:

--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -44,6 +44,12 @@ def detect_cuda_toolkit(repository_ctx):
         ptxas_path = repository_ctx.which("ptxas")
         if ptxas_path:
             # ${CUDA_PATH}/bin/ptxas
+
+            # Some distributions instead put CUDA binaries in a seperate path
+            # Manually check and redirect there when necessary
+            alternative = repository_ctx.path('/usr/lib/nvidia-cuda-toolkit/bin/nvcc')
+            if str(ptxas_path) == "/usr/bin/ptxas" and alternative.exists:
+                ptxas_path = alternative
             cuda_path = str(ptxas_path.dirname.dirname)
     if cuda_path == None and _is_linux(repository_ctx):
         cuda_path = "/usr/local/cuda"
@@ -98,11 +104,12 @@ def config_cuda_toolkit_and_nvcc(repository_ctx, cuda):
     defs_bzl_content = ""
     defs_if_local_cuda = "def if_local_cuda(if_true, if_false = []):\n    return %s\n"
     if cuda.path != None:
-        repository_ctx.symlink(cuda.path + '/bin', "cuda/bin")
-        if repository_ctx.path(cuda.path).get_child('lib', 'x86_64-linux-gnu').exists:
-            repository_ctx.symlink(cuda.path + '/lib/x86_64-linux-gnu', "cuda/lib64")
+        # When using a special cuda toolkit path install, need to manually fix up the lib64 links
+        if cuda.path == "/usr/lib/nvidia-cuda-toolkit":
+            repository_ctx.symlink(cuda.path + "/bin", "cuda/bin")
+            repository_ctx.symlink("/usr/lib/x86_64-linux-gnu", "cuda/lib64")
         else:
-            repository_ctx.symlink(cuda.path + '/lib64', "cuda/lib64")
+            repository_ctx.symlink(cuda.path, "cuda")
         repository_ctx.symlink(Label("//cuda:runtime/BUILD.local_cuda"), "BUILD")
         defs_bzl_content += defs_if_local_cuda % "if_true"
     else:

--- a/cuda/runtime/BUILD.local_cuda
+++ b/cuda/runtime/BUILD.local_cuda
@@ -11,7 +11,9 @@ filegroup(
         ":_cuda_header_files",
     ] + glob([
         "cuda/version.txt",
-        "cuda/bin/**",
+        "cuda/bin/nvcc",
+        "cuda/bin/nvlink",
+        "cuda/bin/bin2c",
         "cuda/lib64/**",
         "cuda/nvvm/**",
     ]),

--- a/cuda/runtime/BUILD.local_cuda
+++ b/cuda/runtime/BUILD.local_cuda
@@ -11,9 +11,7 @@ filegroup(
         ":_cuda_header_files",
     ] + glob([
         "cuda/version.txt",
-        "cuda/bin/nvcc",
-        "cuda/bin/nvlink",
-        "cuda/bin/bin2c",
+        "cuda/bin/**",
         "cuda/lib64/**",
         "cuda/nvvm/**",
     ]),


### PR DESCRIPTION
The rules for this repository do not currently work with the following commonly used CUDA configuration: https://lambdalabs.com/lambda-stack-deep-learning-software

The reason is because the Lambda deep stack installs CUDA in /usr/bin, which breaks a couple of assumptions with this software.

In particular:
- /usr/lib64 is the wrong path here, /usr/lib/x86_64-linux-gnu/ is correct. 
- /usr/bin/** is invalid since it contains recursive symlinks

This fixes those two issues. 