### PR TITLE
Stop using ubuntu-18.04

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -14,8 +14,7 @@ jobs:
     strategy:
       matrix:
         cases:
-          - { os: "ubuntu-18.04", cuda-version: "10.1.243", source: "nvidia" }
-          - { os: "ubuntu-18.04", cuda-version: "11.2.2", source: "nvidia" }
+          - { os: "ubuntu-20.04", cuda-version: "11.2.2", source: "nvidia" }
           - { os: "ubuntu-20.04", cuda-version: "11.6.2", source: "nvidia" }
           - { os: "ubuntu-22.04", cuda-version: "11.5.1-1ubuntu1", source: "ubuntu" }
           - { os: "windows-2019", cuda-version: "10.1.243", source: "nvidia" }

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-22.04
         cuda-version:
           - 11.6.2
     steps:


### PR DESCRIPTION
[Test Examples Build (CUDA 10.1.243 on ubuntu-18.04)](https://github.com/bazel-contrib/rules_cuda/actions/runs/4543560869/jobs/8008403992)
This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on April 1st, 2023. For more details, see https://github.com/actions/runner-images/issues/6002