### PR TITLE
Allow //cuda:copts to be repeatable

### DIFF
--- a/cuda/BUILD.bazel
+++ b/cuda/BUILD.bazel
@@ -3,9 +3,8 @@ load(
     "@bazel_skylib//rules:common_settings.bzl",
     "bool_flag",
     "string_flag",
-    "string_list_flag",
 )
-load("//cuda/private:rules/flags.bzl", "cuda_archs_flag")
+load("//cuda/private:rules/flags.bzl", "cuda_archs_flag", "cuda_copts_flag")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -67,9 +66,9 @@ config_setting(
 )
 
 # Command line flag for copts to add to cuda_library() compile command.
-string_list_flag(
+cuda_copts_flag(
     name = "copts",
-    build_setting_default = [],
+    build_setting_default = "",
 )
 
 # Command line flag to specify the CUDA runtime. Use this target as CUDA

--- a/cuda/private/rules/flags.bzl
+++ b/cuda/private/rules/flags.bzl
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("//cuda/private:cuda_helper.bzl", "cuda_helper")
 load("//cuda/private:providers.bzl", "CudaArchsInfo")
 
@@ -44,4 +45,13 @@ Best Practices:
     implementation = _cuda_archs_flag_impl,
     build_setting = config.string(flag = True),
     provides = [CudaArchsInfo],
+)
+
+def _cuda_copts_flag_impl(ctx):
+    return BuildSettingInfo(value = ctx.build_setting_value)
+
+cuda_copts_flag = rule(
+    implementation = _cuda_copts_flag_impl,
+    build_setting = config.string(flag = True, allow_multiple = True),
+    provides = [BuildSettingInfo],
 )


### PR DESCRIPTION
Fix https://github.com/bazel-contrib/rules_cuda/issues/84

NOTE: the `allow_multiple` is deprecated, we shall switch to use `config.string_list(..., repeatable=True)` in the future.