### PR TITLE
allow .cpp and .cc files in srcs

### DIFF
--- a/cuda/private/rules/common.bzl
+++ b/cuda/private/rules/common.bzl
@@ -7,6 +7,7 @@ ALLOW_CUDA_HDRS = [
 ]
 
 ALLOW_CUDA_SRCS = [
+    ".cc",
+    ".cpp",
     ".cu",
-    ".cu.cc",
 ]


### PR DESCRIPTION
NVCC is perfectly happy to compile these, and this is actually useful for my use case of having a single source that is compilable both as a regular cc_library and a cuda_library, depending on preprocessor directives inside the code.