### PR TITLE
Slow the renovate  bot down

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"]
+  "extends": ["config:base"],
+  "schedule": ["on the first day of the month"]
 }


### PR DESCRIPTION
Renovate is triggered too frequently compare to feature update, leaving too many unnecessary unnecessary commit history.