### PR TITLE
Add NPP

### DIFF
--- a/cuda/runtime/BUILD.local_cuda
+++ b/cuda/runtime/BUILD.local_cuda
@@ -516,7 +516,7 @@ _NPP_LIBS = {
 [
     cc_import(
         name = name + "_lib",
-        interface_library = "cuda/lib/x64/nppc.lib",
+        interface_library = "cuda/lib/x64/{}.lib".format(name),
         system_provided = 1,
         target_compatible_with = ["@platforms//os:windows"],
     )

--- a/cuda/runtime/BUILD.local_cuda
+++ b/cuda/runtime/BUILD.local_cuda
@@ -473,3 +473,67 @@ cc_library(
         ":nvtx_lib",
     ]),
 )
+
+# NPP
+_NPP_LIBS = {
+    "nppc": [
+        "npp.h",
+        "nppcore.h",
+        "nppdefs.h",
+    ],
+    "nppial": ["nppi_arithmetic_and_logical_operations.h"],
+    "nppicc": ["nppi_color_conversion.h"],
+    "nppidei": ["nppi_data_exchange_and_initialization.h"],
+    "nppif": ["nppi_filtering_functions.h"],
+    "nppig": ["nppi_geometry_transforms.h"],
+    "nppim": ["nppi_morphological_operations.h"],
+    "nppist": [
+        "nppi_statistics_functions.h",
+        "nppi_linear_transforms.h",
+    ],
+    "nppisu": ["nppi_support_functions.h"],
+    "nppitc": ["nppi_threshold_and_compare_operations.h"],
+    "npps": [
+        "npps_arithmetic_and_logical_operations.h",
+        "npps_conversion_functions.h",
+        "npps_filtering_functions.h",
+        "npps.h",
+        "npps_initialization.h",
+        "npps_statistics_functions.h",
+        "npps_support_functions.h",
+    ],
+}
+
+[
+    cc_import(
+        name = name + "_so",
+        shared_library = "cuda/lib64/lib{}.so".format(name),
+        target_compatible_with = ["@platforms//os:linux"],
+    )
+    for name in _NPP_LIBS.keys()
+]
+
+[
+    cc_import(
+        name = name + "_lib",
+        interface_library = "cuda/lib/x64/nppc.lib",
+        system_provided = 1,
+        target_compatible_with = ["@platforms//os:windows"],
+    )
+    for name in _NPP_LIBS.keys()
+]
+
+[
+    cc_library(
+        name = name,
+        hdrs = ["cuda/include/" + hdr for hdr in hdrs],
+        includes = ["cuda/include"],
+        visibility = ["//visibility:public"],
+        deps = ([":nppc"] if name != "nppc" else []) + if_linux([
+            ":{}_so".format(name),
+        ]) + if_windows([
+            ":{}_lib".format(name),
+        ]),
+    )
+    for name, hdrs in _NPP_LIBS.items()
+]


### PR DESCRIPTION
I have a .cuh file that does `#include <nppi_geometry_transforms.h>` and uses `nppiResize_8u_C1R_Ctx()`

Now I can just add `deps = ["@local_cuda//:nppig"],` to the target and it will link properly.


See https://docs.nvidia.com/cuda/npp/index.html