### PR TITLE
set nvcc flags for device debug info

### DIFF
--- a/cuda/private/toolchain_configs/nvcc.bzl
+++ b/cuda/private/toolchain_configs/nvcc.bzl
@@ -329,7 +329,7 @@ def _impl(ctx):
         flag_sets = [
             flag_set(
                 actions = [ACTION_NAMES.cuda_compile],
-                flag_groups = [flag_group(flags = ["-Xcompiler", "-g1"])],
+                flag_groups = [flag_group(flags = ["--generate-line-info", "-Xcompiler", "-g1"])],
             ),
         ],
         provides = ["compilation_mode"],

--- a/cuda/private/toolchain_configs/nvcc.bzl
+++ b/cuda/private/toolchain_configs/nvcc.bzl
@@ -298,7 +298,7 @@ def _impl(ctx):
         flag_sets = [
             flag_set(
                 actions = [ACTION_NAMES.cuda_compile],
-                flag_groups = [flag_group(flags = ["-g"])],
+                flag_groups = [flag_group(flags = ["--device-debug", "-g"])],
             ),
         ],
         provides = ["compilation_mode"],


### PR DESCRIPTION
- set `nvcc --device-debug` when `compilation_mode=dbg`
- set `nvcc --generate-line-info` when `compilation_mode=fastbuild`
