### PR TITLE
Ignore MODULE.bazel for renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
+  "ignorePaths": ["MODULE.bazel"],
   "schedule": ["on the first day of the month"]
 }


### PR DESCRIPTION
In #117, bzlmod deps is auto updated but is not desired. Configure renovate bot to ignore `MODULE.bazel` scanning to avoid future auto updating.