### PR TITLE
set nvcc --generate-line-info when compilation_mode=fastbuild

### DIFF
--- a/cuda/private/toolchain_configs/nvcc.bzl
+++ b/cuda/private/toolchain_configs/nvcc.bzl
@@ -331,7 +331,7 @@ def _impl(ctx):
         flag_sets = [
             flag_set(
                 actions = [ACTION_NAMES.cuda_compile],
-                flag_groups = [flag_group(flags = ["-Xcompiler", "-g1"])],
+                flag_groups = [flag_group(flags = ["--generate-line-info", "-Xcompiler", "-g1"])],
             ),
         ],
         provides = ["compilation_mode"],

--- a/tests/flag/BUILD.bazel
+++ b/tests/flag/BUILD.bazel
@@ -47,7 +47,10 @@ cuda_library_c_dbg_flag_test(
 cuda_library_c_fastbuild_flag_test(
     name = "cuda_library_c_fastbuild_flag_test",
     action_mnemonic = "CudaCompile",
-    contain_flags = ["-g1"],
+    contain_flags = [
+        "--generate-line-info",
+        "-g1",
+    ],
     not_contain_flags = ["-DNDEBUG"],
     target_compatible_with = ["@platforms//os:linux"],
     target_under_test = "@rules_cuda_examples//basic:kernel",


### PR DESCRIPTION
this makes the debug info for both host and device code the same
(i.e. --generate-line-info does for device code what -g1 does for
host code).

This is an intuitive result IMO.
