### PR TITLE
have cuda_library output RDC

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -70,13 +70,13 @@ jobs:
         if: ${{ startsWith(matrix.cases.os, 'windows') }}
         run: .github/workflows/Set-VSEnv.ps1 2019
 
-      - run: bazelisk build @rules_cuda_examples//basic:main
-      - run: bazelisk build @rules_cuda_examples//rdc:main
+      - run: bazelisk build @rules_cuda_examples//basic:all
+      - run: bazelisk build @rules_cuda_examples//rdc:all
       - run: bazelisk build @rules_cuda_examples//if_cuda:main
       - run: bazelisk build @rules_cuda_examples//if_cuda:main --enable_cuda=False
 
-      - run: cd examples && bazelisk build //basic:main --config=bzlmod
-      - run: cd examples && bazelisk build //rdc:main --config=bzlmod
+      - run: cd examples && bazelisk build //basic:all --config=bzlmod
+      - run: cd examples && bazelisk build //rdc:all --config=bzlmod
       - run: cd examples && bazelisk build //if_cuda:main --config=bzlmod
       - run: cd examples && bazelisk build //if_cuda:main --enable_cuda=False --config=bzlmod
 

--- a/examples/rdc/BUILD.bazel
+++ b/examples/rdc/BUILD.bazel
@@ -1,29 +1,52 @@
 load("@rules_cuda//cuda:defs.bzl", "cuda_library", "cuda_objects")
 
 cuda_objects(
-    name = "a",
+    name = "a_objects",
     srcs = ["a.cu"],
     deps = [":b"],
 )
 
 cuda_objects(
-    name = "b",
+    name = "b_objects",
     srcs = ["b.cu"],
     hdrs = ["b.cuh"],
 )
 
 cuda_library(
-    name = "librdc",
-    rdc = 1,
+    name = "lib_from_objects",
+    rdc = True,
     deps = [
-        ":a",
-        ":b",
+        ":a_objects",
+        ":b_objects",
     ],
 )
 
 cc_binary(
-    name = "main",
+    name = "main_from_objects",
     deps = [
-        ":librdc",
+        ":lib_from_objects",
+    ],
+)
+
+# Another way of doing it is to just use cuda_library
+cuda_library(
+    name = "a",
+    srcs = ["a.cu"],
+    rdc = True,
+    deps = [":b"],
+)
+
+cuda_library(
+    name = "b",
+    srcs = ["b.cu"],
+    hdrs = ["b.cuh"],
+    rdc = True,
+)
+
+cc_binary(
+    name = "main_from_library",
+    deps = [
+        ":a",
+        ":b",
     ],
 )


### PR DESCRIPTION
This allows a `cuda_library` that was built with `rdc=True` to be
depended upon by another such library. This is convenient as such a
library can be consumed by either another `cuda_library` OR a
`cc_library`.

Note: if we have this, I'm not sure why we need a separate cuda_objects
rule anymore. Perhaps it can be removed in a later PR.

Change-Id: I1014d28a0ab3a9c76b788821211b13c4a9956d2a
