### PR TITLE
Fix obvious typo of templates

### DIFF
--- a/cuda/templates/BUILD.local_toolchain_nvcc
+++ b/cuda/templates/BUILD.local_toolchain_nvcc
@@ -10,7 +10,7 @@ load(
 cuda_toolkit(
     name = "cuda-toolkit",
     bin2c = "%{bin2c_label}",
-    fatbinary = "%{bin2c_label}",
+    fatbinary = "%{fatbinary_label}",
     link_stub = "%{link_stub_label}",
     nvlink = "%{nvlink_label}",
     path = "%{cuda_path}",

--- a/cuda/templates/BUILD.local_toolchain_nvcc_msvc
+++ b/cuda/templates/BUILD.local_toolchain_nvcc_msvc
@@ -10,7 +10,7 @@ load(
 cuda_toolkit(
     name = "cuda-toolkit",
     bin2c = "%{bin2c_label}",
-    fatbinary = "%{bin2c_label}",
+    fatbinary = "%{fatbinary_label}",
     link_stub = "%{link_stub_label}",
     nvlink = "%{nvlink_label}",
     path = "%{cuda_path}",


### PR DESCRIPTION
This is harmless, as fatbinary is not used in nvcc. It is only used when `_wrapper_device_link` is called in clang toolchain.