### PR TITLE
Fix incorrect tools label for _wrapper_device_link

### DIFF
--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -61,19 +61,19 @@ def detect_cuda_toolkit(repository_ctx):
         cuda_path = None
 
     bin_ext = ".exe" if _is_windows(repository_ctx) else ""
-    nvlink = "@rules_cuda//cuda/dummy:nvlink"
-    link_stub = "@rules_cuda//cuda/dummy:link.stub"
-    bin2c = "@rules_cuda//cuda/dummy:bin2c"
-    fatbinary = "@rules_cuda//cuda/dummy:fatbinary"
+    nvlink = Label("@rules_cuda//cuda/dummy:nvlink")
+    link_stub = Label("@rules_cuda//cuda/dummy:link.stub")
+    bin2c = Label("@rules_cuda//cuda/dummy:bin2c")
+    fatbinary = Label("@rules_cuda//cuda/dummy:fatbinary")
     if cuda_path != None:
         if repository_ctx.path(cuda_path + "/bin/nvlink" + bin_ext).exists:
-            nvlink = ":cuda/bin/nvlink{}".format(bin_ext)
+            nvlink = Label("@local_cuda//:cuda/bin/nvlink{}".format(bin_ext))
         if repository_ctx.path(cuda_path + "/bin/crt/link.stub").exists:
-            link_stub = ":cuda/bin/crt/link.stub"
+            link_stub = Label("@local_cuda//:cuda/bin/crt/link.stub")
         if repository_ctx.path(cuda_path + "/bin/bin2c" + bin_ext).exists:
-            bin2c = ":cuda/bin/bin2c{}".format(bin_ext)
+            bin2c = Label("@local_cuda//:cuda/bin/bin2c{}".format(bin_ext))
         if repository_ctx.path(cuda_path + "/bin/fatbinary" + bin_ext).exists:
-            fatbinary = ":cuda/bin/fatbinary{}".format(bin_ext)
+            fatbinary = Label("@local_cuda//:cuda/bin/fatbinary{}".format(bin_ext))
 
     nvcc_version_major = -1
     nvcc_version_minor = -1
@@ -89,10 +89,10 @@ def detect_cuda_toolkit(repository_ctx):
         # this is extracted from `nvcc --version`
         nvcc_version_major = nvcc_version_major,
         nvcc_version_minor = nvcc_version_minor,
-        nvlink_label = nvlink,
-        link_stub_label = link_stub,
-        bin2c_label = bin2c,
-        fatbinary_label = fatbinary,
+        nvlink_label = str(nvlink),
+        link_stub_label = str(link_stub),
+        bin2c_label = str(bin2c),
+        fatbinary_label = str(fatbinary),
     )
 
 def config_cuda_toolkit_and_nvcc(repository_ctx, cuda):


### PR DESCRIPTION
Label, for example, `:cuda/bin/crt/link.stub` is incorrect in

https://github.com/bazel-contrib/rules_cuda/blob/3ce19bc587f5f4404402340e43a22fb192c17dac/cuda/private/repositories.bzl#L69-L76


Prior to #66 it was, `@local_cuda//:cuda/bin/crt/link.stub` which resolves to `<local_cuda>/cuda/bin/crt/link.stub` , but the generated BUILD file resides in `<local_cuda>/toolchain/BUILD`, so `:cuda/bin/crt/link.stub` actually resolves to `<local_cuda>/toolchain/cuda/bin/crt/link.stub` which does not exists.