### PR TITLE
support specaified CUDA Version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,7 @@
 module(
     name = "rules_cuda",
-    compatibility_level = 1,
     version = "0.0.0",
+    compatibility_level = 1,
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.4.2")
@@ -14,4 +14,3 @@ register_toolchains(
     "@local_cuda//toolchain:nvcc-local-toolchain",
     "@local_cuda//toolchain/clang:clang-local-toolchain",
 )
-

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -7,7 +7,10 @@ local_repository(
 
 load("//cuda:repositories.bzl", "register_detected_cuda_toolchains", "rules_cuda_dependencies")
 
-rules_cuda_dependencies()
+rules_cuda_dependencies(
+    cuda_version = "11.8",
+    dll_runtime_system_provided = False,
+)
 
 register_detected_cuda_toolchains()
 

--- a/cuda/defs.bzl
+++ b/cuda/defs.bzl
@@ -3,7 +3,7 @@ Core rules for building CUDA projects.
 """
 
 load("//cuda/private:providers.bzl", _CudaArchsInfo = "CudaArchsInfo", _cuda_archs = "cuda_archs")
-load("//cuda/private:os_helpers.bzl", _cc_import_versioned_sos = "cc_import_versioned_sos", _if_linux = "if_linux", _if_windows = "if_windows")
+load("//cuda/private:os_helpers.bzl", _cc_import_versioned_sos = "cc_import_versioned_sos", _if_linux = "if_linux", _if_windows = "if_windows", _win_share_library_provided_runtime = "win_share_library_provided_runtime")
 load("//cuda/private:rules/cuda_objects.bzl", _cuda_objects = "cuda_objects")
 load("//cuda/private:rules/cuda_library.bzl", _cuda_library = "cuda_library")
 load("//cuda/private:rules/cuda_toolkit.bzl", _cuda_toolkit = "cuda_toolkit")
@@ -35,3 +35,5 @@ if_linux = _if_linux
 if_windows = _if_windows
 
 cc_import_versioned_sos = _cc_import_versioned_sos
+
+win_share_library_provided_runtime = _win_share_library_provided_runtime

--- a/cuda/private/os_helpers.bzl
+++ b/cuda/private/os_helpers.bzl
@@ -35,3 +35,31 @@ def cc_import_versioned_sos(name, shared_library):
         name = name,
         deps = [":%s" % paths.basename(p) for p in so_paths],
     )
+
+def win_share_library_provided_runtime(name, system_provided = True):
+    """Creates a cc_library that depends on all versioned .so files with the given prefix.
+
+    If <shared_library> is path/to/foo.so, and it is a symlink to foo.so.<version>,
+    this should be used instead of cc_import.
+    The versioned files are typically needed at runtime, but not at build time.
+
+    Args:
+        name: Name of the cc_library.
+        shared_library: Prefix of the versioned .so files.
+    """
+    so_paths = native.glob(["cuda/bin/{}64_*.dll".format(name)])
+    interface_library = "cuda/lib/x64/{}.lib".format(name)
+    if len(so_paths) == 1 and not system_provided:
+        native.cc_import(
+            name = name + "_lib",
+            interface_library = interface_library,
+            shared_library = str(so_paths[0]),
+            target_compatible_with = ["@platforms//os:windows"],
+        )
+    else:
+        native.cc_import(
+            name = name + "_lib",
+            interface_library = interface_library,
+            system_provided = 1,
+            target_compatible_with = ["@platforms//os:windows"],
+        )

--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -41,7 +41,47 @@ def detect_cuda_toolkit(repository_ctx):
         A struct contains the information of CUDA Toolkit.
     """
     cuda_path = repository_ctx.attr.toolkit_path
-    if cuda_path == "":
+    if cuda_path == "" and repository_ctx.attr.cuda_version != "":
+        cuda_path = None
+        system_cuda_path = None
+        if system_cuda_path == None:
+            system_cuda_path = repository_ctx.os.environ.get("CUDA_PATH", None)
+        if system_cuda_path == None:
+            ptxas_path = repository_ctx.which("ptxas")
+            if ptxas_path:
+                # ${CUDA_PATH}/bin/ptxas
+                system_cuda_path = str(ptxas_path.dirname.dirname)
+
+        if _is_windows(repository_ctx) and repository_ctx.attr.cuda_version != None:
+            if cuda_path == None and system_cuda_path != None:
+                system_cuda_dir = str(repository_ctx.path(system_cuda_path).dirname)
+                cuda_path = system_cuda_dir + "/v" + repository_ctx.attr.cuda_version
+                if not repository_ctx.path(cuda_path).exists:
+                    cuda_path = None
+            if cuda_path == None:
+                cuda_default_prefix = "C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v"
+                cuda_path = cuda_default_prefix + repository_ctx.attr.cuda_version
+                if not repository_ctx.path(cuda_path).exists:
+                    cuda_path = None
+            if cuda_path == None:
+                print("cuda set version not support")
+        if _is_linux(repository_ctx) and repository_ctx.attr.cuda_version != None:
+            if cuda_path == None and system_cuda_path != None:
+                # system cuda path /usr/local/cuda -> system cuda dir : /usr/local
+                system_cuda_dir = str(repository_ctx.path(system_cuda_path).dirname)
+                cuda_path = system_cuda_dir + "/cuda-" + repository_ctx.attr.cuda_version
+                if not repository_ctx.path(cuda_path).exists:
+                    cuda_path = None
+            if cuda_path == None:
+                cuda_default_prefix = "/usr/local/cuda-"
+                cuda_path = cuda_default_prefix + repository_ctx.attr.cuda_version
+                if not repository_ctx.path(cuda_path).exists:
+                    print("cuda set version not support")
+                    cuda_path = None
+            if cuda_path == None:
+                print("cuda set version not support")
+
+    if cuda_path == None or cuda_path == "":
         cuda_path = repository_ctx.os.environ.get("CUDA_PATH", None)
     if cuda_path == None:
         ptxas_path = repository_ctx.which("ptxas")
@@ -80,10 +120,14 @@ def detect_cuda_toolkit(repository_ctx):
 
     if cuda_path != None:
         nvcc_version_major, nvcc_version_minor = _get_nvcc_version(repository_ctx, cuda_path)
+    else:
+        fail("cuda path not found in this system")
 
+    dll_runtime_system_provided = repository_ctx.attr.dll_runtime_system_provided
     return struct(
         path = cuda_path,
         # this should have been extracted from cuda.h, reuse nvcc for now
+        dll_runtime_system_provided = dll_runtime_system_provided,
         version_major = nvcc_version_major,
         version_minor = nvcc_version_minor,
         # this is extracted from `nvcc --version`
@@ -118,6 +162,11 @@ def config_cuda_toolkit_and_nvcc(repository_ctx, cuda):
     else:
         repository_ctx.file("BUILD")  # Empty file
         defs_bzl_content += defs_if_local_cuda % "if_false"
+    defs_if_dll_runtime_system_provided = "def  dll_runtime_system_provided():\n    return %s\n"
+    if cuda.dll_runtime_system_provided:
+        defs_bzl_content += defs_if_dll_runtime_system_provided % "True"
+    else:
+        defs_bzl_content += defs_if_dll_runtime_system_provided % "False"
     repository_ctx.file("defs.bzl", defs_bzl_content)
 
     # Generate @local_cuda//toolchain/BUILD
@@ -199,17 +248,22 @@ def _local_cuda_impl(repository_ctx):
 
 local_cuda = repository_rule(
     implementation = _local_cuda_impl,
-    attrs = {"toolkit_path": attr.string(mandatory = False)},
+    attrs = {
+        "cuda_version": attr.string(mandatory = False),
+        "toolkit_path": attr.string(mandatory = False),
+        "dll_runtime_system_provided": attr.bool(mandatory = False),
+    },
     configure = True,
     local = True,
     environ = ["CUDA_PATH", "PATH", "CUDA_CLANG_PATH", "BAZEL_LLVM"],
     # remotable = True,
 )
 
-def rules_cuda_dependencies(toolkit_path = None):
+def rules_cuda_dependencies(toolkit_path = None, cuda_version = None, dll_runtime_system_provided = True):
     """Populate the dependencies for rules_cuda. This will setup workspace dependencies (other bazel rules) and local toolchains.
 
     Args:
+        cuda_version: Optionally specify CUDA toolkit version from system. If not exit, it will be detected automatically.
         toolkit_path: Optionally specify the path to CUDA toolkit. If not specified, it will be detected automatically.
     """
     maybe(
@@ -232,4 +286,4 @@ def rules_cuda_dependencies(toolkit_path = None):
         ],
     )
 
-    local_cuda(name = "local_cuda", toolkit_path = toolkit_path)
+    local_cuda(name = "local_cuda", toolkit_path = toolkit_path, cuda_version = cuda_version, dll_runtime_system_provided = dll_runtime_system_provided)

--- a/cuda/runtime/BUILD.local_cuda
+++ b/cuda/runtime/BUILD.local_cuda
@@ -1,4 +1,5 @@
-load("@rules_cuda//cuda:defs.bzl", "cc_import_versioned_sos", "if_linux", "if_windows")
+load("@rules_cuda//cuda:defs.bzl", "cc_import_versioned_sos", "if_linux", "if_windows", "win_share_library_provided_runtime")
+load(":defs.bzl", "dll_runtime_system_provided")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -49,17 +50,16 @@ cc_library(
     target_compatible_with = ["@platforms//os:linux"],
 )
 
-cc_import(
-    name = "cudart_lib",
-    interface_library = "cuda/lib/x64/cudart.lib",
-    system_provided = 1,
-    target_compatible_with = ["@platforms//os:windows"],
+win_share_library_provided_runtime(
+    name = "cudart",
+    system_provided = dll_runtime_system_provided(),
 )
 
 cc_import(
     name = "cudadevrt_lib",
     interface_library = "cuda/lib/x64/cudadevrt.lib",
     system_provided = 1,
+    #shared_library = "cuda/bin/cudart64_"+ cuda_package_version("cuda_cudart") + ".dll",
     target_compatible_with = ["@platforms//os:windows"],
 )
 
@@ -144,18 +144,14 @@ cc_import_versioned_sos(
     shared_library = "cuda/lib64/libcublasLt.so",
 )
 
-cc_import(
-    name = "cublas_lib",
-    interface_library = "cuda/lib/x64/cublas.lib",
-    system_provided = 1,
-    target_compatible_with = ["@platforms//os:windows"],
+win_share_library_provided_runtime(
+    name = "cublas",
+    system_provided = dll_runtime_system_provided(),
 )
 
-cc_import(
-    name = "cublasLt_lib",
-    interface_library = "cuda/lib/x64/cublasLt.lib",
-    system_provided = 1,
-    target_compatible_with = ["@platforms//os:windows"],
+win_share_library_provided_runtime(
+    name = "cublasLt",
+    system_provided = dll_runtime_system_provided(),
 )
 
 cc_library(
@@ -301,11 +297,9 @@ cc_import_versioned_sos(
     shared_library = "cuda/lib64/libcurand.so",
 )
 
-cc_import(
-    name = "curand_lib",
-    interface_library = "cuda/lib/x64/curand.lib",
-    system_provided = 1,
-    target_compatible_with = ["@platforms//os:windows"],
+win_share_library_provided_runtime(
+    name = "curand",
+    system_provided = dll_runtime_system_provided(),
 )
 
 cc_library(
@@ -396,11 +390,9 @@ cc_import_versioned_sos(
     shared_library = "cuda/lib64/libcusolver.so",
 )
 
-cc_import(
-    name = "cusolver_lib",
-    interface_library = "cuda/lib/x64/cusolver.lib",
-    system_provided = 1,
-    target_compatible_with = ["@platforms//os:windows"],
+win_share_library_provided_runtime(
+    name = "cusolver",
+    system_provided = dll_runtime_system_provided(),
 )
 
 cc_library(
@@ -420,11 +412,9 @@ cc_import_versioned_sos(
     shared_library = "cuda/lib64/libcusparse.so",
 )
 
-cc_import(
-    name = "cusparse_lib",
-    interface_library = "cuda/lib/x64/cusparse.lib",
-    system_provided = 1,
-    target_compatible_with = ["@platforms//os:windows"],
+win_share_library_provided_runtime(
+    name = "cusparse",
+    system_provided = dll_runtime_system_provided(),
 )
 
 cc_library(

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -1,14 +1,18 @@
 module(
     name = "rules_cuda_examples",
-    compatibility_level = 1,
     version = "0.0.0",
+    compatibility_level = 1,
 )
 
 bazel_dep(name = "rules_cuda", version = "0.1.3")
-local_path_override(module_name = "rules_cuda", path = "..")
+local_path_override(
+    module_name = "rules_cuda",
+    path = "..",
+)
 
 cuda = use_extension("@rules_cuda//cuda:extensions.bzl", "toolchain")
-
-cuda.local_toolchain(name = "local_cuda", toolkit_path = "")
-
+cuda.local_toolchain(
+    name = "local_cuda",
+    toolkit_path = "",
+)
 use_repo(cuda, "local_cuda")

--- a/examples/WORKSPACE.bazel
+++ b/examples/WORKSPACE.bazel
@@ -14,6 +14,9 @@ local_repository(
 
 load("@rules_cuda//cuda:repositories.bzl", "register_detected_cuda_toolchains", "rules_cuda_dependencies")
 
-rules_cuda_dependencies()
+rules_cuda_dependencies(
+    cuda_version = "11.8",
+    dll_runtime_system_provided = False,
+)
 
 register_detected_cuda_toolchains()


### PR DESCRIPTION
support specaified CUDA Version

Issue:
In some cases, system have different version's CUDA toolkit ，so it need to specified CUDA version param（like Windows CI client-server ，and need to build history code to get stable unified products ）

so it to need to specified CUDA version
If special CUDA version , bazel test need to get special CUDA version's shared library runtime file ( dll file)
effect :
if not set cuda_version or dll_runtime_system_provided param (default none or True), it will be no impact
if set CUDA version and can not find cuda_version 's CUDA toolkit, it will find CUDA in system as old logic, it will be no impact