### PR TITLE
Update bazel_skylib to 1.4.2

### DIFF
--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -215,10 +215,10 @@ def rules_cuda_dependencies(toolkit_path = None):
     maybe(
         name = "bazel_skylib",
         repo_rule = http_archive,
-        sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+        sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
         ],
     )
 


### PR DESCRIPTION
`MODULE.bazel` is already updated to the new versionin 09e10b36f02c2e4bca81a7a8c77b094ccc59aa87, sync them up.

This also includes the `expand_template` in new release, and it is used in the upcomming integration example and test.