### PR TITLE
Update matrix versions

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         cases:
           - { os: "ubuntu-20.04", cuda-version: "11.2.2", source: "nvidia" }
-          - { os: "ubuntu-20.04", cuda-version: "11.6.2", source: "nvidia" }
+          - { os: "ubuntu-22.04", cuda-version: "11.8.0", source: "nvidia" }
           - {
               os: "ubuntu-20.04",
               cuda-version: "11.6.2",

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         os:
           - ubuntu-22.04
         cuda-version:
-          - 11.6.2
+          - 11.8.0
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
ubuntu-22.04 repo only has 11.7 as the minimium version of cuda toolkit, it seems that nvidia has pulled some old versions from the apt repo.