### PR TITLE
Improve RDC

### DIFF
--- a/cuda/private/cuda_helper.bzl
+++ b/cuda/private/cuda_helper.bzl
@@ -308,7 +308,16 @@ def _create_common(ctx):
         transitive_linking_contexts = transitive_linking_contexts,
     )
 
-def _create_cuda_info(defines = None, objects = None, rdc_objects = None, pic_objects = None, rdc_pic_objects = None):
+def _create_cuda_info(
+        defines = None,
+        objects = None,
+        rdc_objects = None,
+        pic_objects = None,
+        rdc_pic_objects = None,
+        transitive_objects = None,
+        transitive_rdc_objects = None,
+        transitive_pic_objects = None,
+        transitive_rdc_pic_objects = None):
     """Constructor for `CudaInfo`. See the providers documentation for detail."""
     ret = CudaInfo(
         defines = defines if defines != None else depset([]),
@@ -316,6 +325,10 @@ def _create_cuda_info(defines = None, objects = None, rdc_objects = None, pic_ob
         rdc_objects = rdc_objects if rdc_objects != None else depset([]),
         pic_objects = pic_objects if pic_objects != None else depset([]),
         rdc_pic_objects = rdc_pic_objects if rdc_pic_objects != None else depset([]),
+        transitive_objects = transitive_objects if transitive_objects != None else depset([]),
+        transitive_rdc_objects = transitive_rdc_objects if transitive_rdc_objects != None else depset([]),
+        transitive_pic_objects = transitive_pic_objects if transitive_pic_objects != None else depset([]),
+        transitive_rdc_pic_objects = transitive_rdc_pic_objects if transitive_rdc_pic_objects != None else depset([]),
     )
     return ret
 

--- a/cuda/private/cuda_helper.bzl
+++ b/cuda/private/cuda_helper.bzl
@@ -314,10 +314,10 @@ def _create_cuda_info(
         rdc_objects = None,
         pic_objects = None,
         rdc_pic_objects = None,
-        transitive_objects = None,
-        transitive_rdc_objects = None,
-        transitive_pic_objects = None,
-        transitive_rdc_pic_objects = None):
+        archive_objects = None,
+        archive_rdc_objects = None,
+        archive_pic_objects = None,
+        archive_rdc_pic_objects = None):
     """Constructor for `CudaInfo`. See the providers documentation for detail."""
     ret = CudaInfo(
         defines = defines if defines != None else depset([]),
@@ -325,10 +325,10 @@ def _create_cuda_info(
         rdc_objects = rdc_objects if rdc_objects != None else depset([]),
         pic_objects = pic_objects if pic_objects != None else depset([]),
         rdc_pic_objects = rdc_pic_objects if rdc_pic_objects != None else depset([]),
-        transitive_objects = transitive_objects if transitive_objects != None else depset([]),
-        transitive_rdc_objects = transitive_rdc_objects if transitive_rdc_objects != None else depset([]),
-        transitive_pic_objects = transitive_pic_objects if transitive_pic_objects != None else depset([]),
-        transitive_rdc_pic_objects = transitive_rdc_pic_objects if transitive_rdc_pic_objects != None else depset([]),
+        archive_objects = archive_objects if archive_objects != None else depset([]),
+        archive_rdc_objects = archive_rdc_objects if archive_rdc_objects != None else depset([]),
+        archive_pic_objects = archive_pic_objects if archive_pic_objects != None else depset([]),
+        archive_rdc_pic_objects = archive_rdc_pic_objects if archive_rdc_pic_objects != None else depset([]),
     )
     return ret
 

--- a/cuda/private/cuda_helper.bzl
+++ b/cuda/private/cuda_helper.bzl
@@ -317,7 +317,9 @@ def _create_cuda_info(
         archive_objects = None,
         archive_rdc_objects = None,
         archive_pic_objects = None,
-        archive_rdc_pic_objects = None):
+        archive_rdc_pic_objects = None,
+        dlink_rdc_objects = None,
+        dlink_rdc_pic_objects = None):
     """Constructor for `CudaInfo`. See the providers documentation for detail."""
     ret = CudaInfo(
         defines = defines if defines != None else depset([]),
@@ -329,6 +331,8 @@ def _create_cuda_info(
         archive_rdc_objects = archive_rdc_objects if archive_rdc_objects != None else depset([]),
         archive_pic_objects = archive_pic_objects if archive_pic_objects != None else depset([]),
         archive_rdc_pic_objects = archive_rdc_pic_objects if archive_rdc_pic_objects != None else depset([]),
+        dlink_rdc_objects = dlink_rdc_objects if dlink_rdc_objects != None else depset([]),
+        dlink_rdc_pic_objects = dlink_rdc_pic_objects if dlink_rdc_pic_objects != None else depset([]),
     )
     return ret
 

--- a/cuda/private/providers.bzl
+++ b/cuda/private/providers.bzl
@@ -74,6 +74,11 @@ if merged a single depset.
         "archive_pic_objects": "A depset of rdc pic objects. cuda_objects only. Gathered from the transitive dependencies for archiving.",
         "archive_rdc_objects": "A depset of rdc objects. cuda_objects only. Gathered from the transitive dependencies for archiving or device linking.",
         "archive_rdc_pic_objects": "A depset of rdc pic objects. cuda_objects only. Gathered from the transitive dependencies for archiving or device linking.",
+
+        # transitive dlink only (cuda_library):
+        # NOTE: ideally, we can use the archived library to do the device linking, but the nvlink is not happy with library with *_dlink.o included
+        "dlink_rdc_objects": "A depset of rdc objects. cuda_library only. Gathered from the transitive dependencies for device linking.",
+        "dlink_rdc_pic_objects": "A depset of rdc pic objects. cuda_library only. Gathered from the transitive dependencies for device linking.",
     },
 )
 

--- a/cuda/private/providers.bzl
+++ b/cuda/private/providers.bzl
@@ -59,13 +59,21 @@ CudaInfo = provider(
     """Provides cuda build artifacts that can be consumed by device linking or linking process.
 
 This provider is analog to [CcInfo](https://bazel.build/rules/lib/CcInfo) but only contains necessary information for
-linking in a flat structure.""",
+linking in a flat structure. Objects are grouped by direct and transitive, because we have no way to split them again
+if merged a single depset.
+""",
     fields = {
         "defines": "A depset of strings. It is used for the compilation during device linking.",
-        "objects": "A depset of objects.",  # but not rdc and pic
-        "rdc_objects": "A depset of relocatable device code objects.",  # but not pic
-        "pic_objects": "A depset of position indepentent code objects.",  # but not rdc
-        "rdc_pic_objects": "A depset of relocatable device code and position indepentent code objects.",
+        # direct only:
+        "objects": "A depset of objects. Direct artifacts of the rule.",  # but not rdc and pic
+        "pic_objects": "A depset of position indepentent code objects. Direct artifacts of the rule.",  # but not rdc
+        "rdc_objects": "A depset of relocatable device code objects. Direct artifacts of the rule.",  # but not pic
+        "rdc_pic_objects": "A depset of relocatable device code and position indepentent code objects. Direct artifacts of the rule.",
+        # transitive only:
+        "transitive_objects": "A depset of rdc objects. cuda_objects only. Gathered from the transitive dependencies for archiving.",
+        "transitive_pic_objects": "A depset of rdc pic objects. cuda_objects only. Gathered from the transitive dependencies for archiving.",
+        "transitive_rdc_objects": "A depset of rdc objects. cuda_objects only. Gathered from the transitive dependencies for archiving or device linking.",
+        "transitive_rdc_pic_objects": "A depset of rdc pic objects. cuda_objects only. Gathered from the transitive dependencies for archiving or device linking.",
     },
 )
 

--- a/cuda/private/providers.bzl
+++ b/cuda/private/providers.bzl
@@ -69,11 +69,11 @@ if merged a single depset.
         "pic_objects": "A depset of position indepentent code objects. Direct artifacts of the rule.",  # but not rdc
         "rdc_objects": "A depset of relocatable device code objects. Direct artifacts of the rule.",  # but not pic
         "rdc_pic_objects": "A depset of relocatable device code and position indepentent code objects. Direct artifacts of the rule.",
-        # transitive only:
-        "transitive_objects": "A depset of rdc objects. cuda_objects only. Gathered from the transitive dependencies for archiving.",
-        "transitive_pic_objects": "A depset of rdc pic objects. cuda_objects only. Gathered from the transitive dependencies for archiving.",
-        "transitive_rdc_objects": "A depset of rdc objects. cuda_objects only. Gathered from the transitive dependencies for archiving or device linking.",
-        "transitive_rdc_pic_objects": "A depset of rdc pic objects. cuda_objects only. Gathered from the transitive dependencies for archiving or device linking.",
+        # transitive archive only (cuda_objects):
+        "archive_objects": "A depset of rdc objects. cuda_objects only. Gathered from the transitive dependencies for archiving.",
+        "archive_pic_objects": "A depset of rdc pic objects. cuda_objects only. Gathered from the transitive dependencies for archiving.",
+        "archive_rdc_objects": "A depset of rdc objects. cuda_objects only. Gathered from the transitive dependencies for archiving or device linking.",
+        "archive_rdc_pic_objects": "A depset of rdc pic objects. cuda_objects only. Gathered from the transitive dependencies for archiving or device linking.",
     },
 )
 

--- a/cuda/private/rules/cuda_library.bzl
+++ b/cuda/private/rules/cuda_library.bzl
@@ -28,20 +28,16 @@ def _cuda_library_impl(ctx):
     for src in ctx.attr.srcs:
         src_files.extend(src[DefaultInfo].files.to_list())
 
-    # outputs
+    # direct outputs
     objects = depset(compile(ctx, cuda_toolchain, cc_toolchain, src_files, common, pic = False, rdc = use_rdc))
     pic_objects = depset(compile(ctx, cuda_toolchain, cc_toolchain, src_files, common, pic = True, rdc = use_rdc))
-    rdc_objects = depset([])
-    rdc_pic_objects = depset([])
 
     # if rdc is enabled for this cuda_library, then we need futher do a pass of device link
     if use_rdc:
         transitive_objects = depset(transitive = [dep[CudaInfo].rdc_objects for dep in attr.deps if CudaInfo in dep])
         transitive_pic_objects = depset(transitive = [dep[CudaInfo].rdc_pic_objects for dep in attr.deps if CudaInfo in dep])
         objects = depset(transitive = [objects, transitive_objects])
-        rdc_objects = objects
         pic_objects = depset(transitive = [pic_objects, transitive_pic_objects])
-        rdc_pic_objects = pic_objects
         dlink_object = depset([device_link(ctx, cuda_toolchain, cc_toolchain, objects, common, pic = False, rdc = use_rdc)])
         dlink_pic_object = depset([device_link(ctx, cuda_toolchain, cc_toolchain, pic_objects, common, pic = True, rdc = use_rdc)])
         objects = depset(transitive = [objects, dlink_object])
@@ -91,8 +87,6 @@ def _cuda_library_impl(ctx):
             pic_lib = pic_libs,
             objects = objects,
             pic_objects = pic_objects,
-            rdc_objects = rdc_objects,
-            rdc_pic_objects = rdc_pic_objects,
         ),
         CcInfo(
             compilation_context = cc_info.compilation_context,
@@ -102,8 +96,6 @@ def _cuda_library_impl(ctx):
             defines = depset(common.defines),
             objects = objects,
             pic_objects = pic_objects,
-            rdc_objects = rdc_objects,
-            rdc_pic_objects = rdc_pic_objects,
         ),
     ]
 
@@ -118,10 +110,8 @@ cuda_library = rule(
         "alwayslink": attr.bool(default = False),
         "rdc": attr.bool(
             default = False,
-            doc = ("Whether to produce and consume relocateable device code. " +
-                   "Transitive deps that contain device code must all either be cuda_objects or cuda_library(rdc = True). " +
-                   "If False, all device code must be in the same translation unit. May have performance implications. " +
-                   "See https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#using-separate-compilation-in-cuda."),
+            doc = ("Whether to perform device linking for relocateable device code. " +
+                   "Transitive deps that contain device code must all either be cuda_objects or cuda_library(rdc = True)."),
         ),
         "includes": attr.string_list(doc = "List of include dirs to be added to the compile line."),
         "host_copts": attr.string_list(doc = "Add these options to the CUDA host compilation command."),

--- a/cuda/private/rules/cuda_library.bzl
+++ b/cuda/private/rules/cuda_library.bzl
@@ -48,11 +48,14 @@ def _cuda_library_impl(ctx):
     rdc_objects = depset(compile(ctx, cuda_toolchain, cc_toolchain, src_files, common, pic = False, rdc = True)) if use_rdc else depset([])
     rdc_pic_objects = depset(compile(ctx, cuda_toolchain, cc_toolchain, src_files, common, pic = True, rdc = True)) if use_rdc else depset([])
 
-    # if rdc is enabled for this `cuda_library`, then we need futher do a pass of device link
+    # if rdc is enabled for this `cuda_library`, then we need to do a pass of device link further.
     rdc_dlink_inputs = None
     rdc_pic_dlink_inputs = None
     if use_rdc:
-        # Already implemented Only dlink with objects. TODO: Add support dlink with objects and libraries
+        # TODO: Switch to explicit dlink with attr `dlink=True`, then add support dlink with libraries. At the moment,
+        # all libraries produced by this rule with `rdc=True` will have an <name>_dlink.<infix>.o archived, and nvlink
+        # refuses to consume such libraries and ignores them silently.
+
         # prepare inputs for device_link, take use_rdc=True and non-pic as an example:
         # rdc_objects: produce with this rule
         # archive_rdc_objects: propagate from other `cuda_objects`

--- a/cuda/private/rules/cuda_objects.bzl
+++ b/cuda/private/rules/cuda_objects.bzl
@@ -19,16 +19,21 @@ def _cuda_objects_impl(ctx):
     for src in ctx.attr.srcs:
         src_files.extend(src[DefaultInfo].files.to_list())
 
-    transitive_objects = depset(transitive = [dep[CudaInfo].objects for dep in attr.deps if CudaInfo in dep])
-    transitive_rdc_objects = depset(transitive = [dep[CudaInfo].rdc_objects for dep in attr.deps if CudaInfo in dep])
-    transitive_pic_objects = depset(transitive = [dep[CudaInfo].pic_objects for dep in attr.deps if CudaInfo in dep])
-    transitive_rdc_pic_objects = depset(transitive = [dep[CudaInfo].rdc_pic_objects for dep in attr.deps if CudaInfo in dep])
+    # merge deps' direct objects and transitive objects as our transitive objects
+    transitive_objects = depset(transitive = [dep[CudaInfo].objects for dep in attr.deps if CudaInfo in dep] +
+                                             [dep[CudaInfo].transitive_objects for dep in attr.deps if CudaInfo in dep])
+    transitive_pic_objects = depset(transitive = [dep[CudaInfo].pic_objects for dep in attr.deps if CudaInfo in dep] +
+                                                 [dep[CudaInfo].transitive_pic_objects for dep in attr.deps if CudaInfo in dep])
+    transitive_rdc_objects = depset(transitive = [dep[CudaInfo].rdc_objects for dep in attr.deps if CudaInfo in dep] +
+                                                 [dep[CudaInfo].transitive_rdc_objects for dep in attr.deps if CudaInfo in dep])
+    transitive_rdc_pic_objects = depset(transitive = [dep[CudaInfo].rdc_pic_objects for dep in attr.deps if CudaInfo in dep] +
+                                                     [dep[CudaInfo].transitive_rdc_pic_objects for dep in attr.deps if CudaInfo in dep])
 
-    # outputs
-    objects = depset(compile(ctx, cuda_toolchain, cc_toolchain, src_files, common, pic = False, rdc = False), transitive = [transitive_objects])
-    rdc_objects = depset(compile(ctx, cuda_toolchain, cc_toolchain, src_files, common, pic = False, rdc = True), transitive = [transitive_rdc_objects])
-    pic_objects = depset(compile(ctx, cuda_toolchain, cc_toolchain, src_files, common, pic = True, rdc = False), transitive = [transitive_pic_objects])
-    rdc_pic_objects = depset(compile(ctx, cuda_toolchain, cc_toolchain, src_files, common, pic = True, rdc = True), transitive = [transitive_rdc_pic_objects])
+    # direct outputs
+    objects = depset(compile(ctx, cuda_toolchain, cc_toolchain, src_files, common, pic = False, rdc = False))
+    pic_objects = depset(compile(ctx, cuda_toolchain, cc_toolchain, src_files, common, pic = True, rdc = False))
+    rdc_objects = depset(compile(ctx, cuda_toolchain, cc_toolchain, src_files, common, pic = False, rdc = True))
+    rdc_pic_objects = depset(compile(ctx, cuda_toolchain, cc_toolchain, src_files, common, pic = True, rdc = True))
 
     compilation_ctx = cc_common.create_compilation_context(
         headers = common.headers,
@@ -37,6 +42,11 @@ def _cuda_objects_impl(ctx):
         quote_includes = depset(common.quote_includes),
         defines = depset(common.host_defines),
         local_defines = depset(common.host_local_defines),
+    )
+
+    cc_info = cc_common.merge_cc_infos(
+        direct_cc_infos = [CcInfo(compilation_context = compilation_ctx)],
+        cc_infos = [common.transitive_cc_info],
     )
 
     return [
@@ -60,7 +70,8 @@ def _cuda_objects_impl(ctx):
             rdc_pic_objects = rdc_pic_objects,
         ),
         CcInfo(
-            compilation_context = compilation_ctx,
+            compilation_context = cc_info.compilation_context,
+            linking_context = cc_info.linking_context,
         ),
         cuda_helper.create_cuda_info(
             defines = depset(common.defines),
@@ -68,6 +79,10 @@ def _cuda_objects_impl(ctx):
             pic_objects = pic_objects,
             rdc_objects = rdc_objects,
             rdc_pic_objects = rdc_pic_objects,
+            transitive_objects = transitive_objects,
+            transitive_pic_objects = transitive_pic_objects,
+            transitive_rdc_objects = transitive_rdc_objects,
+            transitive_rdc_pic_objects = transitive_rdc_pic_objects,
         ),
     ]
 

--- a/cuda/private/rules/cuda_objects.bzl
+++ b/cuda/private/rules/cuda_objects.bzl
@@ -19,15 +19,15 @@ def _cuda_objects_impl(ctx):
     for src in ctx.attr.srcs:
         src_files.extend(src[DefaultInfo].files.to_list())
 
-    # merge deps' direct objects and transitive objects as our transitive objects
-    transitive_objects = depset(transitive = [dep[CudaInfo].objects for dep in attr.deps if CudaInfo in dep] +
-                                             [dep[CudaInfo].transitive_objects for dep in attr.deps if CudaInfo in dep])
-    transitive_pic_objects = depset(transitive = [dep[CudaInfo].pic_objects for dep in attr.deps if CudaInfo in dep] +
-                                                 [dep[CudaInfo].transitive_pic_objects for dep in attr.deps if CudaInfo in dep])
-    transitive_rdc_objects = depset(transitive = [dep[CudaInfo].rdc_objects for dep in attr.deps if CudaInfo in dep] +
-                                                 [dep[CudaInfo].transitive_rdc_objects for dep in attr.deps if CudaInfo in dep])
-    transitive_rdc_pic_objects = depset(transitive = [dep[CudaInfo].rdc_pic_objects for dep in attr.deps if CudaInfo in dep] +
-                                                     [dep[CudaInfo].transitive_rdc_pic_objects for dep in attr.deps if CudaInfo in dep])
+    # merge deps' direct objects and archive objects as our archive objects
+    archive_objects = depset(transitive = [dep[CudaInfo].objects for dep in attr.deps if CudaInfo in dep] +
+                                          [dep[CudaInfo].archive_objects for dep in attr.deps if CudaInfo in dep])
+    archive_pic_objects = depset(transitive = [dep[CudaInfo].pic_objects for dep in attr.deps if CudaInfo in dep] +
+                                              [dep[CudaInfo].archive_pic_objects for dep in attr.deps if CudaInfo in dep])
+    archive_rdc_objects = depset(transitive = [dep[CudaInfo].rdc_objects for dep in attr.deps if CudaInfo in dep] +
+                                              [dep[CudaInfo].archive_rdc_objects for dep in attr.deps if CudaInfo in dep])
+    archive_rdc_pic_objects = depset(transitive = [dep[CudaInfo].rdc_pic_objects for dep in attr.deps if CudaInfo in dep] +
+                                                  [dep[CudaInfo].archive_rdc_pic_objects for dep in attr.deps if CudaInfo in dep])
 
     # direct outputs
     objects = depset(compile(ctx, cuda_toolchain, cc_toolchain, src_files, common, pic = False, rdc = False))
@@ -79,10 +79,10 @@ def _cuda_objects_impl(ctx):
             pic_objects = pic_objects,
             rdc_objects = rdc_objects,
             rdc_pic_objects = rdc_pic_objects,
-            transitive_objects = transitive_objects,
-            transitive_pic_objects = transitive_pic_objects,
-            transitive_rdc_objects = transitive_rdc_objects,
-            transitive_rdc_pic_objects = transitive_rdc_pic_objects,
+            archive_objects = archive_objects,
+            archive_pic_objects = archive_pic_objects,
+            archive_rdc_objects = archive_rdc_objects,
+            archive_rdc_pic_objects = archive_rdc_pic_objects,
         ),
     ]
 


### PR DESCRIPTION
1. `cuda_objects` now returns `CcInfo` with linking context, thus, the `cc_library` deps can correctly propagate to `cuda_library`
2. correctly handle transitive objects for archiving and device linking.

This fixed static linking issue introduced by #125, and partially address some concerns mentioned in #164