### PR TITLE
Ignore MODULE.bazel.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 bazel-*
+
+# MODULE.bazel.lock is a new feature in bazel and is not stable yet.
+# Per https://github.com/bazelbuild/bazel/issues/20369, we ignore this file until 
+# MODULE.bazel.lock mechanism is stable and guarantee consistency across different 
+# development environments
+MODULE.bazel.lock


### PR DESCRIPTION
`MODULE.bazel.lock` file is a mechanism under `bzlmod` intended to record package and dependency versions (see Bazel documentation https://bazel.build/external/lockfile). However, this mechanism is not yet stable, for example, it does not seem to guarantee content consistency, and causes version control conflicts, for example see https://github.com/bazelbuild/bazel/issues/20369

So at this moment we put `MODULE.bazel.lock` files (including root directory and subdirectories) into `.gitignore` file.

Resolves #223 