### PR TITLE
ci: disable doc test workflow cache to avoid excessive space wasting

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -26,16 +26,10 @@ jobs:
         if: ${{ matrix.docs.ref != 'main' }}
 
       - uses: bazelbuild/setup-bazelisk@v3
-      - name: Mount bazel cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/bazel
-          key: bazel-gen-docs-${{ matrix.docs.ref }}
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-          cache: pip
 
       - name: Generate docs
         run: bash ./build-docs.sh


### PR DESCRIPTION
Fix #230 