### PR TITLE
Change example rules_cuda version

### DIFF
--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -4,7 +4,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "rules_cuda", version = "0.1.3")
+bazel_dep(name = "rules_cuda", version = "0.2.1")
 local_path_override(
     module_name = "rules_cuda",
     path = "..",


### PR DESCRIPTION
Change example rules_cuda to a version that is availbe within the Bazel Central Registry