### PR TITLE
Do not assume libcupti.so location

### DIFF
--- a/cuda/runtime/BUILD.local_cuda
+++ b/cuda/runtime/BUILD.local_cuda
@@ -210,7 +210,7 @@ cc_library(
 # CUPTI
 cc_import_versioned_sos(
     name = "cupti_so",
-    shared_library = "cuda/lib64/libcupti.so",
+    shared_library = "cuda/**/lib64/libcupti.so",
 )
 
 cc_import(


### PR DESCRIPTION
`libcupti.so` can sometimes be located under `cuda/extras/CUPTI/lib64/` instead