### PR TITLE
ci: use absolute path for XDG_CACHE_HOME as github actions and bazel doesn't resolve `~` automatically

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,8 +35,8 @@ jobs:
           method: network
       - name: bazel test //...
         env:
-          # Bazelisk will download bazel to here
-          XDG_CACHE_HOME: ~/.cache/bazel-repo
+          # Bazelisk will download bazel to here, ensure it is cached within tests.
+          XDG_CACHE_HOME: /home/runner/.cache/bazel-repo
         run: bazelisk --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
       - name: Create rules archive
         run: |


### PR DESCRIPTION
CI log:
```console
ERROR: Skipping '//...': error loading package under directory '': error loading package '~/.cache/bazel-repo/bazel/_bazel_runner/c7158fce5becee297c399541ca8c3db4/install/rules_java/toolchains': at /home/runner/work/rules_cuda/rules_cuda/~/.cache/bazel-repo/bazel/_bazel_runner/c7158fce5becee297c399541ca8c3db4/install/rules_java/toolchains/java_toolchain_alias.bzl:17:6: Label '//java/common:java_common.bzl' is invalid because 'java/common' is not a package; perhaps you meant to put the colon here: '//:java/common/java_common.bzl'?
ERROR: error loading package under directory '': error loading package '~/.cache/bazel-repo/bazel/_bazel_runner/c7158fce5becee297c399541ca8c3db4/install/rules_java/toolchains': at /home/runner/work/rules_cuda/rules_cuda/~/.cache/bazel-repo/bazel/_bazel_runner/c7158fce5becee297c399541ca8c3db4/install/rules_java/toolchains/java_toolchain_alias.bzl:17:6: Label '//java/common:java_common.bzl' is invalid because 'java/common' is not a package; perhaps you meant to put the colon here: '//:java/common/java_common.bzl'?
```

https://github.com/bazelbuild/bazel/issues/22894#issuecomment-2202327572
> Bazel doesn't resolve `~` to the home directory and instead creates the cache in a subdirectory of the WORKSPACE called `~`.