### PR TITLE
ci: cover major bazel releases in utilities tests

### DIFF
--- a/.github/workflows/utilities-tests.yaml
+++ b/.github/workflows/utilities-tests.yaml
@@ -17,8 +17,9 @@ jobs:
           - ubuntu-20.04
           - windows-2019
         bazel-version:
-          - 5.0.0
-          - 5.2.0
+          - latest
+          - 6.5.0
+          - 5.4.1
     env:
       USE_BAZEL_VERSION: ${{ matrix.bazel-version }}
     steps:


### PR DESCRIPTION
This reveal the release pipeline failure