### PR TITLE
test: workaround label resolving with bzlmod

### DIFF
--- a/tests/flag/flag_validation_test.bzl
+++ b/tests/flag/flag_validation_test.bzl
@@ -59,7 +59,14 @@ def _create_cuda_library_flag_test(*config_settings):
     merged_config_settings = {}
     for cs in config_settings:
         for k, v in cs.items():
-            merged_config_settings[k] = v
+            # https://github.com/bazelbuild/bazel/issues/19286#issuecomment-1684325913
+            # Wrapping all keys into str(Label(...)) should be a workaround with Bazel 6 and later.
+            # NOTE: //command_line_option will resolve to @@//command_line_option which is not correct.
+            # Only apply to cuda related labels
+            if "cuda" in k:
+                merged_config_settings[str(Label(k))] = v
+            else:
+                merged_config_settings[k] = v
     return analysistest.make(
         cuda_library_flag_test_impl,
         config_settings = merged_config_settings,

--- a/tests/flag/flag_validation_test.bzl
+++ b/tests/flag/flag_validation_test.bzl
@@ -62,8 +62,9 @@ def _create_cuda_library_flag_test(*config_settings):
             # https://github.com/bazelbuild/bazel/issues/19286#issuecomment-1684325913
             # Wrapping all keys into str(Label(...)) should be a workaround with Bazel 6 and later.
             # NOTE: //command_line_option will resolve to @@//command_line_option which is not correct.
-            # Only apply to cuda related labels
-            if "cuda" in k:
+            # Only apply to cuda related labels when bzlmod is enabled
+            is_bzlmod_enabled = str(Label("//:invalid")).startswith("@@")
+            if is_bzlmod_enabled and "cuda" in k:
                 merged_config_settings[str(Label(k))] = v
             else:
                 merged_config_settings[k] = v


### PR DESCRIPTION
Partially fix test failures triggered by #262

Workaround utilities test when bzlmod is enabled:
```
ERROR: Traceback (most recent call last):
	File "/home/runner/work/rules_cuda/rules_cuda/tests/flag/flag_validation_test.bzl", line 98, column 61, in <toplevel>
		cuda_library_sm61_flag_test = _create_cuda_library_flag_test(config_settings_sm61)
	File "/home/runner/work/rules_cuda/rules_cuda/tests/flag/flag_validation_test.bzl", line 63, column 29, in _create_cuda_library_flag_test
		return analysistest.make(
	File "/home/runner/.cache/bazel/_bazel_runner/c7158fce5becee297c399541ca8c3db4/external/bazel_skylib~/lib/unittest.bzl", line [28](https://github.com/bazel-contrib/rules_cuda/actions/runs/10286317527/job/28467427384?pr=262#step:6:29)5, column 51, in _make_analysis_test
		test_transition = analysis_test_transition(
Error in analysis_test_transition: invalid transition output '@@[unknown repo '' requested from @@bazel_skylib~]//cuda:archs': no repo visible as @ from repository '@@bazel_skylib~'
ERROR: error loading package under directory 'tests': error loading package 'tests/flag': initialization of module 'tests/flag/flag_validation_test.bzl' failed
```