### PR TITLE
Clarify SRI checksum needed by archive_override()

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ bazel_dep(name = "rules_cuda", version = "0.2.1")
 # pick a specific version (this is optional an can be skipped)
 archive_override(
     module_name = "rules_cuda",
-    integrity = "{SRI value}",  # see https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
+    integrity = "{checksum in SRI format}",  # see https://www.w3.org/TR/SRI/
     urls = "https://github.com/bazel-contrib/rules_cuda/archive/{git_commit_hash}.tar.gz",
     strip_prefix = "rules_cuda-{git_commit_hash}",
 )


### PR DESCRIPTION
Instead of hexadecimal string of checksum, The SRI value must be in the format like `sha256-{base64(checksum)}`. [mdn.io/sri#tools_for_generating_sri_hashes](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity#tools_for_generating_sri_hashes) shows a few ways to generate the SRI values.