### PR TITLE
fix(bcr): add basic presubmit yaml

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,12 +1,9 @@
-# We recommend included a bcr test workspace that exercises your ruleset with bzlmod.
-# For an example, see https://github.com/aspect-build/bazel-lib/tree/main/e2e/bzlmod.
-#bcr_test_module:
-#  module_path: "examples"
-#  matrix:
-#    platform: ["debian10", "macos", "ubuntu2004", "windows"]
-#  tasks:
-#    run_tests:
-#      name: "Run test module"
-#      platform: ${{ platform }}
-#      test_targets:
-#        - "//..."
+matrix:
+  bazel:
+  - 6.x
+  - 7.x
+tasks:
+  verify_targets_linux:
+    name: Verify build targets
+    bazel: ${{ bazel }}
+    platform: ubuntu2004

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,7 +1,7 @@
 matrix:
   bazel:
-  - 6.x
-  - 7.x
+    - 6.x
+    - 7.x
 tasks:
   verify_targets_linux:
     name: Verify build targets


### PR DESCRIPTION
- add basic presubmit yaml to pass bcr ci for the PR generated automatically
- related to https://github.com/bazelbuild/bazel-central-registry/pull/2731