### PR TITLE
feat: `load("@rules_cuda_redist_json//:redist.bzl", "rules_cuda_components")`

### DIFF
--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -337,6 +337,74 @@ def default_components_mapping(components):
     """
     return {c: "@local_cuda_" + c for c in components}
 
+def _cuda_redist_json_impl(repository_ctx):
+    the_url = None  # the url that successfully fetch redist json, we then use it to fetch deliverables
+    urls = [u for u in repository_ctx.attr.urls]
+
+    redist_ver = repository_ctx.attr.version
+    if redist_ver:
+        urls.append("https://developer.download.nvidia.com/compute/cuda/redist/redistrib_{}.json".format(redist_ver))
+
+    if len(urls) == 0:
+        fail("`urls` or `version` must be specified.")
+
+    for url in urls:
+        ret = repository_ctx.download(
+            output = "redist.json",
+            integrity = repository_ctx.attr.integrity,
+            sha256 = repository_ctx.attr.sha256,
+            url = url,
+        )
+        if ret.success:
+            the_url = url
+            break
+
+    if the_url == None:
+        fail("Failed to retrieve the redist json file.")
+
+    # convert redist.json to list of spec (list of dicts with cuda_components attrs)
+    specs = []
+    redist = json.decode(repository_ctx.read("redist.json"))
+    if not redist_ver:
+        redist_ver = redist["release_label"]
+    for c in repository_ctx.attr.components:
+        c_full = FULL_COMPONENT_NAME[c]
+        os = None
+        if _is_linux(repository_ctx):
+            os = "linux"
+        elif _is_windows(repository_ctx):
+            os = "windows"
+
+        arch = "x86_64"  # TODO: support cross compiling
+        platform = "{os}-{arch}".format(os = os, arch = arch)
+
+        payload = redist[c_full][platform]
+        payload_relative_path = payload["relative_path"]
+        payload_url = the_url.rsplit("/", 1)[0] + "/" + payload_relative_path
+        archive_name = payload_relative_path.rsplit("/", 1)[1].split("-archive.")[0] + "-archive"
+
+        specs.append({
+            "component_name": c,
+            "urls": [payload_url],
+            "sha256": payload["sha256"],
+            "strip_prefix": archive_name,
+            "version": redist[c_full]["version"],
+        })
+
+    template_helper.generate_redist_bzl(repository_ctx, specs, redist_ver)
+    repository_ctx.symlink(Label("//cuda/private:templates/BUILD.redist_json"), "BUILD")
+
+cuda_redist_json = repository_rule(
+    implementation = _cuda_redist_json_impl,
+    attrs = {
+        "components": attr.string_list(mandatory = True),
+        "integrity": attr.string(mandatory = False),
+        "sha256": attr.string(mandatory = False),
+        "urls": attr.string_list(mandatory = False),
+        "version": attr.string(mandatory = False),
+    },
+)
+
 def rules_cuda_dependencies():
     """Populate the dependencies for rules_cuda. This will setup other bazel rules as workspace dependencies"""
     maybe(

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -89,6 +89,50 @@ def _generate_defs_bzl(repository_ctx, is_local_ctk):
     }
     repository_ctx.template("defs.bzl", tpl_label, substitutions = substitutions, executable = False)
 
+def _generate_redist_bzl(repository_ctx, component_specs, redist_version):
+    """Generate `@rules_cuda_redist_json//:redist.bzl`
+
+    Args:
+        repository_ctx: repository_ctx
+        component_specs: list of dict, dict keys are component_name, urls, sha256, strip_prefix and version
+    """
+
+    rules_cuda_components_body = []
+    mapping = {}
+
+    component_tpl = """cuda_component(
+        name = "{repo_name}",
+        component_name = "{component_name}",
+        sha256 = {sha256},
+        strip_prefix = {strip_prefix},
+        urls = {urls},
+    )"""
+
+    for spec in component_specs:
+        repo_name = "local_cuda_" + spec["component_name"]
+        version = spec.get("version", None)
+        if version != None:
+            repo_name = repo_name + "_v" + version
+
+        rules_cuda_components_body.append(
+            component_tpl.format(
+                repo_name = repo_name,
+                component_name = spec["component_name"],
+                sha256 = repr(spec["sha256"]),
+                strip_prefix = repr(spec["strip_prefix"]),
+                urls = repr(spec["urls"]),
+            ),
+        )
+        mapping[spec["component_name"]] = "@" + repo_name
+
+    tpl_label = Label("//cuda/private:templates/redist.bzl.tpl")
+    substitutions = {
+        "%{rules_cuda_components_body}": "\n\n    ".join(rules_cuda_components_body),
+        "%{components_mapping}": repr(mapping),
+        "%{version}": redist_version,
+    }
+    repository_ctx.template("redist.bzl", tpl_label, substitutions = substitutions, executable = False)
+
 def _generate_toolchain_build(repository_ctx, cuda):
     tpl_label = Label(
         "//cuda/private:templates/BUILD.local_toolchain_" +
@@ -127,6 +171,7 @@ def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path):
 template_helper = struct(
     generate_build = _generate_build,
     generate_defs_bzl = _generate_defs_bzl,
+    generate_redist_bzl = _generate_redist_bzl,
     generate_toolchain_build = _generate_toolchain_build,
     generate_toolchain_clang_build = _generate_toolchain_clang_build,
 )

--- a/cuda/private/templates/BUILD.redist_json
+++ b/cuda/private/templates/BUILD.redist_json
@@ -1,0 +1,18 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "redist_bzl",
+    srcs = [":redist.bzl"],
+)
+
+filegroup(
+    name = "redist_json",
+    srcs = [":redist.json"],
+)
+
+exports_files([
+    "redist.bzl",
+    "redist.json",
+])

--- a/cuda/private/templates/redist.bzl.tpl
+++ b/cuda/private/templates/redist.bzl.tpl
@@ -1,0 +1,15 @@
+load("@rules_cuda//cuda:repositories.bzl", "cuda_component", "rules_cuda_toolchains")
+
+def rules_cuda_components():
+    # See template_helper.generate_redist_bzl(...) for body generation logic
+    %{rules_cuda_components_body}
+
+    return %{components_mapping}
+
+def rules_cuda_components_and_toolchains(register_toolchains = False):
+    components_mapping = rules_cuda_components()
+    rules_cuda_toolchains(
+        components_mapping= components_mapping,
+        register_toolchains = register_toolchains,
+        version = "%{version}",
+    )

--- a/cuda/repositories.bzl
+++ b/cuda/repositories.bzl
@@ -1,6 +1,7 @@
 load(
     "//cuda/private:repositories.bzl",
     _cuda_component = "cuda_component",
+    _cuda_redist_json = "cuda_redist_json",
     _default_components_mapping = "default_components_mapping",
     _local_cuda = "local_cuda",
     _rules_cuda_dependencies = "rules_cuda_dependencies",
@@ -10,6 +11,7 @@ load("//cuda/private:toolchain.bzl", _register_detected_cuda_toolchains = "regis
 
 # rules
 cuda_component = _cuda_component
+cuda_redist_json = _cuda_redist_json
 local_cuda = _local_cuda
 
 # macros

--- a/tests/integration/test_all.sh
+++ b/tests/integration/test_all.sh
@@ -71,3 +71,14 @@ pushd "$this_dir/toolchain_components"
     bazel build --enable_bzlmod //:use_rule
     bazel clean && bazel shutdown
 popd
+
+# toolchain configured with deliverables (redistrib.json with workspace)
+pushd "$this_dir/toolchain_redist_json"
+    bazel build --enable_workspace //... --@rules_cuda//cuda:enable=False
+    bazel build --enable_workspace //... --@rules_cuda//cuda:enable=True
+    bazel build --enable_workspace //:optinally_use_rule --@rules_cuda//cuda:enable=False
+    bazel build --enable_workspace //:optinally_use_rule --@rules_cuda//cuda:enable=True
+    bazel build --enable_workspace //:use_library
+    bazel build --enable_workspace //:use_rule
+    bazel clean && bazel shutdown
+popd

--- a/tests/integration/toolchain_redist_json/BUILD.bazel
+++ b/tests/integration/toolchain_redist_json/BUILD.bazel
@@ -1,0 +1,1 @@
+../BUILD.to_symlink

--- a/tests/integration/toolchain_redist_json/MODULE.bazel
+++ b/tests/integration/toolchain_redist_json/MODULE.bazel
@@ -1,0 +1,53 @@
+module(name = "bzlmod_components")
+
+# FIXME: cuda_redist_json is not exposed in bzlmod now. Fallback to manually specified components for tests
+bazel_dep(name = "rules_cuda", version = "0.0.0")
+local_path_override(
+    module_name = "rules_cuda",
+    path = "../../..",
+)
+
+cuda = use_extension("@rules_cuda//cuda:extensions.bzl", "toolchain")
+cuda.component(
+    name = "local_cuda_cccl",
+    component_name = "cccl",
+    sha256 = "9c3145ef01f73e50c0f5fcf923f0899c847f487c529817daa8f8b1a3ecf20925",
+    strip_prefix = "cuda_cccl-linux-x86_64-12.6.77-archive",
+    urls = ["https://developer.download.nvidia.com/compute/cuda/redist/cuda_cccl/linux-x86_64/cuda_cccl-linux-x86_64-12.6.77-archive.tar.xz"],
+)
+cuda.component(
+    name = "local_cuda_cudart",
+    component_name = "cudart",
+    sha256 = "f74689258a60fd9c5bdfa7679458527a55e22442691ba678dcfaeffbf4391ef9",
+    strip_prefix = "cuda_cudart-linux-x86_64-12.6.77-archive",
+    urls = ["https://developer.download.nvidia.com/compute/cuda/redist/cuda_cudart/linux-x86_64/cuda_cudart-linux-x86_64-12.6.77-archive.tar.xz"],
+)
+cuda.component(
+    name = "local_cuda_nvcc",
+    component_name = "nvcc",
+    sha256 = "840deff234d9bef20d6856439c49881cb4f29423b214f9ecd2fa59b7ac323817",
+    strip_prefix = "cuda_nvcc-linux-x86_64-12.6.85-archive",
+    urls = ["https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvcc/linux-x86_64/cuda_nvcc-linux-x86_64-12.6.85-archive.tar.xz"],
+)
+cuda.toolkit(
+    name = "local_cuda",
+    components_mapping = {
+        "cccl": "@local_cuda_cccl",
+        "cudart": "@local_cuda_cudart",
+        "nvcc": "@local_cuda_nvcc",
+    },
+    version = "12.6",
+)
+use_repo(
+    cuda,
+    "local_cuda",
+    "local_cuda_cccl",
+    "local_cuda_cudart",
+    "local_cuda_nvcc",
+)
+
+bazel_dep(name = "rules_cuda_examples", version = "0.0.0")
+local_path_override(
+    module_name = "rules_cuda_examples",
+    path = "../../../examples",
+)

--- a/tests/integration/toolchain_redist_json/WORKSPACE.bazel
+++ b/tests/integration/toolchain_redist_json/WORKSPACE.bazel
@@ -1,0 +1,23 @@
+local_repository(
+    name = "rules_cuda",
+    path = "../../..",
+)
+
+# buildifier: disable=load-on-top
+load("@rules_cuda//cuda:repositories.bzl", "cuda_redist_json", "rules_cuda_dependencies")
+
+rules_cuda_dependencies()
+
+cuda_redist_json(
+    name = "rules_cuda_redist_json",
+    components = [
+        "cccl",
+        "cudart",
+        "nvcc",
+    ],
+    version = "12.6.3",
+)
+
+load("@rules_cuda_redist_json//:redist.bzl", "rules_cuda_components_and_toolchains")
+
+rules_cuda_components_and_toolchains(register_toolchains = True)


### PR DESCRIPTION
#283

`cuda_redist_json` repo rule download the `redistrib.json` (redist_json) from the `urls`, or download from nvidia's default repo if only `version` is specified. In the repo, we generate a `redist.bzl` file. The `redist.bzl` contains macros with wrapped `cuda_component` repo rules of the components specified in the `cuda_redist_json`'s `components` attribute.

For example,
```starlark
cuda_redist_json(
    name = "rules_cuda_redist_json",
    components = [
        "cccl",
        "cudart",
        "nvcc",
    ],
    version = "12.6.3",
)
```

- Downloads `redistrib.json` from `https://developer.download.nvidia.com/compute/cuda/redist/redistrib_12.6.3.json`
- Generates a `redist.bzl` with the content as follows:
   ```
   def rules_cuda_components():
       cuda_component(
           name = "local_cuda_cccl_v12.6.77",
           component_name = "cccl",
           # sha256, strip_prefix and urls automatically filled by reading redist.json
       )
   
       cuda_component(
           name = "local_cuda_cudart_v12.6.77",
           component_name = "cudart",
           # sha256, strip_prefix and urls automatically filled by reading redist.json
       )
   
       cuda_component(
           name = "local_cuda_nvcc_v12.6.85",
           component_name = "nvcc",
           # sha256, strip_prefix and urls automatically filled by reading redist.json
       )
   
       return {"cccl": "@local_cuda_cccl_v12.6.77", "cudart": "@local_cuda_cudart_v12.6.77", "nvcc": "@local_cuda_nvcc_v12.6.85"}
   
   def rules_cuda_components_and_toolchains(register_toolchains = False):
       components_mapping = rules_cuda_components()
       rules_cuda_toolchains(
           components_mapping= components_mapping,
           register_toolchains = register_toolchains,
           version = "12.6.3",
       )
   ```

User then
```
load("@rules_cuda_redist_json//:redist.bzl", "rules_cuda_components_and_toolchains")
rules_cuda_components_and_toolchains(register_toolchains = True)
```

Only WORKSPACE based project is addressed in this PR.