### PR TITLE
Add NVRTC to local_cuda

### DIFF
--- a/cuda/runtime/BUILD.local_cuda
+++ b/cuda/runtime/BUILD.local_cuda
@@ -317,6 +317,31 @@ cc_library(
     ]),
 )
 
+# NVRTC
+cc_import(
+    name = "nvrtc_so",
+    shared_library = "cuda/lib64/libnvrtc.so",
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+cc_import(
+    name = "nvrtc_lib",
+    interface_library = "cuda/lib/x64/nvrtc.lib",
+    system_provided = 1,
+    target_compatible_with = ["@platforms//os:windows"],
+)
+
+cc_library(
+    name = "nvrtc",
+    deps = [
+        ":cuda_headers",
+    ] + if_linux([
+        ":nvrtc_so",
+    ]) + if_windows([
+        ":nvrtc_lib",
+    ]),
+)
+
 # curand
 cc_import_versioned_sos(
     name = "curand_so",

--- a/cuda/runtime/BUILD.local_cuda
+++ b/cuda/runtime/BUILD.local_cuda
@@ -318,10 +318,9 @@ cc_library(
 )
 
 # NVRTC
-cc_import(
+cc_import_versioned_sos(
     name = "nvrtc_so",
     shared_library = "cuda/lib64/libnvrtc.so",
-    target_compatible_with = ["@platforms//os:linux"],
 )
 
 cc_import(


### PR DESCRIPTION
[NVRTC](https://docs.nvidia.com/cuda/nvrtc/) (runtime compilation library for CUDA C++) is part of the CUDA Toolkit. This PR adds a target for the NVRTC library.