### PR TITLE
Make stardoc in sync with WORKSPACE usage

### DIFF
--- a/docs/MODULE.bazel
+++ b/docs/MODULE.bazel
@@ -17,4 +17,8 @@ cuda.local_toolchain(
 )
 use_repo(cuda, "local_cuda")
 
-bazel_dep(name = "stardoc", version = "0.6.2")
+bazel_dep(
+    name = "stardoc", 
+    version = "0.7.0",
+    repo_name = "io_bazel_stardoc",
+)

--- a/docs/MODULE.bazel
+++ b/docs/MODULE.bazel
@@ -18,7 +18,7 @@ cuda.local_toolchain(
 use_repo(cuda, "local_cuda")
 
 bazel_dep(
-    name = "stardoc", 
+    name = "stardoc",
     version = "0.7.0",
     repo_name = "io_bazel_stardoc",
 )


### PR DESCRIPTION
Initially unblocks [upgrade to Bazel 8](https://github.com/bazel-contrib/rules_cuda/pull/308)

For the PR upgrading Bazel to v8 (where `WORKSPACE` is disabled by default), the first error is because of the absence of the `io_bazel_stardoc` in [this action run](https://github.com/bazel-contrib/rules_cuda/actions/runs/12565394242/job/35029612602?pr=308).

For this, I added the `repo_name` to add an alias since [some usage](https://github.com/bazel-contrib/rules_cuda/blob/d5416e1fadbfe79ee0b4bf4165dc3cd78ce68242/docs/BUILD.bazel#L2) still expects the name to be `io_bazel_stardoc`.

I also noticed that WORKSPACE has stardoc v0.7.0 but MODULE.bazel is still lagging behind, therefore bumped it up to match. 
