### PR TITLE
fix: search for the `sysroot` in compile args

### DIFF
--- a/cuda/private/cuda_helper.bzl
+++ b/cuda/private/cuda_helper.bzl
@@ -4,6 +4,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:types.bzl", "types")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", CC_ACTION_NAMES = "ACTION_NAMES")
 load("//cuda/private:action_names.bzl", "ACTION_NAMES")
 load("//cuda/private:artifact_categories.bzl", "ARTIFACT_CATEGORIES")
 load("//cuda/private:providers.bzl", "ArchSpecInfo", "CudaArchsInfo", "CudaInfo", "Stage2ArchInfo", "cuda_archs")
@@ -230,6 +231,36 @@ def _create_common_info(
         transitive_linking_contexts = transitive_linking_contexts,
     )
 
+def _get_sysroot(ctx):
+    cc_toolchain = find_cpp_toolchain(ctx)
+
+    if cc_toolchain.sysroot:
+        return "--sysroot=%s" % cc_toolchain.sysroot
+
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
+    variables = cc_common.create_compile_variables(
+        cc_toolchain = cc_toolchain,
+        feature_configuration = feature_configuration,
+    )
+
+    cc_flags = cc_common.get_memory_inefficient_command_line(
+        feature_configuration = feature_configuration,
+        action_name = CC_ACTION_NAMES.cpp_compile,
+        variables = variables,
+    )
+
+    for flag in cc_flags:
+        if flag.startswith("--sysroot="):
+            return flag.removeprefix("--sysroot=")
+
+    return None
+
 def _create_common(ctx):
     """Helper to gather and process various information from `ctx` object to ease the parameter passing for internal macros.
 
@@ -243,7 +274,7 @@ def _create_common(ctx):
 
     merged_cc_info = cc_common.merge_cc_infos(cc_infos = [dep[CcInfo] for dep in all_cc_deps])
 
-    cc_toolchain = find_cpp_toolchain(ctx)
+    sysroot = _get_sysroot(ctx)
 
     # gather include info
     includes = merged_cc_info.compilation_context.includes.to_list()
@@ -279,8 +310,8 @@ def _create_common(ctx):
     host_defines = []
     host_local_defines = [i for i in attr.host_local_defines]
     host_compile_flags = attr._default_host_copts[BuildSettingInfo].value + [i for i in attr.host_copts]
-    if cc_toolchain.sysroot:
-        host_compile_flags.append("--sysroot={}".format(cc_toolchain.sysroot))
+    if sysroot:
+        host_compile_flags.append("--sysroot={}".format(sysroot))
     host_link_flags = []
     if hasattr(attr, "host_linkopts"):
         host_link_flags.extend([i for i in attr.host_linkopts])


### PR DESCRIPTION
Wit the new `cc_rules` based toolchains, the `sysroot` on the toolchain is not set. But we can infer it from the command line args a normal compilation with that toolchain would get.