### PR TITLE
fix(nvcc): append to `cpp_compile` `PATH`

### DIFF
--- a/cuda/private/toolchain_configs/nvcc.bzl
+++ b/cuda/private/toolchain_configs/nvcc.bzl
@@ -49,14 +49,30 @@ def _impl(ctx):
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
-    host_compiler = cc_common.get_tool_for_action(feature_configuration = cc_feature_configuration, action_name = CC_ACTION_NAMES.cpp_compile)
+    host_compiler = cc_common.get_tool_for_action(
+        feature_configuration = cc_feature_configuration,
+        action_name = CC_ACTION_NAMES.cpp_compile,
+    )
+
+    c_compile_variables = cc_common.create_compile_variables(
+        feature_configuration = cc_feature_configuration,
+        cc_toolchain = cc_toolchain,
+    )
+    env = cc_common.get_environment_variables(
+        feature_configuration = cc_feature_configuration,
+        action_name = CC_ACTION_NAMES.cpp_compile,
+        variables = c_compile_variables,
+    )
+
+    # We know we are linux here, so ":" should be save.
+    path = ":".join([env.get("PATH", ""), paths.dirname(host_compiler)])
 
     nvcc_compile_env_feature = feature(
         name = "nvcc_compile_env",
         env_sets = [
             env_set(
                 actions = [ACTION_NAMES.cuda_compile],
-                env_entries = [env_entry("PATH", paths.dirname(host_compiler))],
+                env_entries = [env_entry("PATH", path)],
             ),
         ],
     )
@@ -66,7 +82,7 @@ def _impl(ctx):
         env_sets = [
             env_set(
                 actions = [ACTION_NAMES.device_link],
-                env_entries = [env_entry("PATH", paths.dirname(host_compiler))],
+                env_entries = [env_entry("PATH", path)],
             ),
         ],
     )


### PR DESCRIPTION
Instead of reducing the PATH of the `cpp_compile` action to only the dir of the host compiler, we can query we toolchain for the configured PATH and append the directory of the host compiler.

This way 1) nvcc can still find the host compiler from the PATH and 2) a potential compiler wrapper script that acts as the host compiler can still find its dependencies.