### PR TITLE
refactor: remove use_cpp_toolchain

### DIFF
--- a/cuda/private/rules/cuda_library.bzl
+++ b/cuda/private/rules/cuda_library.bzl
@@ -1,10 +1,10 @@
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load("//cuda/private:actions/compile.bzl", "compile")
 load("//cuda/private:actions/dlink.bzl", "device_link")
 load("//cuda/private:cuda_helper.bzl", "cuda_helper")
 load("//cuda/private:providers.bzl", "CudaInfo")
 load("//cuda/private:rules/common.bzl", "ALLOW_CUDA_HDRS", "ALLOW_CUDA_SRCS")
-load("//cuda/private:toolchain.bzl", "find_cuda_toolchain", "use_cpp_toolchain", "use_cuda_toolchain")
+load("//cuda/private:toolchain.bzl", "find_cuda_toolchain", "use_cuda_toolchain")
 
 def _cuda_library_impl(ctx):
     """cuda_library is a rule that perform device link.

--- a/cuda/private/rules/cuda_objects.bzl
+++ b/cuda/private/rules/cuda_objects.bzl
@@ -1,9 +1,9 @@
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load("//cuda/private:actions/compile.bzl", "compile")
 load("//cuda/private:cuda_helper.bzl", "cuda_helper")
 load("//cuda/private:providers.bzl", "CudaInfo")
 load("//cuda/private:rules/common.bzl", "ALLOW_CUDA_HDRS", "ALLOW_CUDA_SRCS")
-load("//cuda/private:toolchain.bzl", "find_cuda_toolchain", "use_cpp_toolchain", "use_cuda_toolchain")
+load("//cuda/private:toolchain.bzl", "find_cuda_toolchain", "use_cuda_toolchain")
 
 def _cuda_objects_impl(ctx):
     attr = ctx.attr

--- a/cuda/private/toolchain.bzl
+++ b/cuda/private/toolchain.bzl
@@ -49,20 +49,13 @@ cuda_toolchain = rule(
         "compiler_files": attr.label(allow_files = True, cfg = "exec", doc = "The set of files that are needed when compiling using this toolchain."),
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
     },
+    toolchains = use_cpp_toolchain(),
 )
 
 CPP_TOOLCHAIN_TYPE = "@bazel_tools//tools/cpp:toolchain_type"
 CUDA_TOOLCHAIN_TYPE = "//cuda:toolchain_type"
 
 # buildifier: disable=unused-variable
-def use_cpp_toolchain(mandatory = True):
-    """Helper to depend on the C++ toolchain.
-
-    Notes:
-        Copied from [toolchain_utils.bzl](https://github.com/bazelbuild/bazel/blob/ac48e65f70/tools/cpp/toolchain_utils.bzl#L53-L72)
-    """
-    return [CPP_TOOLCHAIN_TYPE]
-
 def use_cuda_toolchain():
     """Helper to depend on the CUDA toolchain."""
     return [CUDA_TOOLCHAIN_TYPE]

--- a/cuda/private/toolchain.bzl
+++ b/cuda/private/toolchain.bzl
@@ -49,10 +49,8 @@ cuda_toolchain = rule(
         "compiler_files": attr.label(allow_files = True, cfg = "exec", doc = "The set of files that are needed when compiling using this toolchain."),
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
     },
-    toolchains = use_cpp_toolchain(),
 )
 
-CPP_TOOLCHAIN_TYPE = "@bazel_tools//tools/cpp:toolchain_type"
 CUDA_TOOLCHAIN_TYPE = "//cuda:toolchain_type"
 
 # buildifier: disable=unused-variable

--- a/cuda/private/toolchain_configs/clang.bzl
+++ b/cuda/private/toolchain_configs/clang.bzl
@@ -1,10 +1,9 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", CC_ACTION_NAMES = "ACTION_NAMES")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load("//cuda/private:action_names.bzl", "ACTION_NAMES")
 load("//cuda/private:artifact_categories.bzl", "ARTIFACT_CATEGORIES")
 load("//cuda/private:providers.bzl", "CudaToolchainConfigInfo", "CudaToolkitInfo")
-load("//cuda/private:toolchain.bzl", "use_cpp_toolchain")
 load(
     "//cuda/private:toolchain_config_lib.bzl",
     "action_config",

--- a/cuda/private/toolchain_configs/nvcc.bzl
+++ b/cuda/private/toolchain_configs/nvcc.bzl
@@ -1,10 +1,9 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", CC_ACTION_NAMES = "ACTION_NAMES")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load("//cuda/private:action_names.bzl", "ACTION_NAMES")
 load("//cuda/private:artifact_categories.bzl", "ARTIFACT_CATEGORIES")
 load("//cuda/private:providers.bzl", "CudaToolchainConfigInfo", "CudaToolkitInfo")
-load("//cuda/private:toolchain.bzl", "use_cpp_toolchain")
 load(
     "//cuda/private:toolchain_config_lib.bzl",
     "action_config",

--- a/cuda/private/toolchain_configs/nvcc_msvc.bzl
+++ b/cuda/private/toolchain_configs/nvcc_msvc.bzl
@@ -1,10 +1,9 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/build_defs/cc:action_names.bzl", CC_ACTION_NAMES = "ACTION_NAMES")
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load("//cuda/private:action_names.bzl", "ACTION_NAMES")
 load("//cuda/private:artifact_categories.bzl", "ARTIFACT_CATEGORIES")
 load("//cuda/private:providers.bzl", "CudaToolchainConfigInfo", "CudaToolkitInfo")
-load("//cuda/private:toolchain.bzl", "use_cpp_toolchain")
 load(
     "//cuda/private:toolchain_config_lib.bzl",
     "action_config",

--- a/docs/developer_docs.bzl
+++ b/docs/developer_docs.bzl
@@ -12,14 +12,12 @@ load(
     "@rules_cuda//cuda/private:toolchain.bzl",
     _find_cuda_toolchain = "find_cuda_toolchain",
     _find_cuda_toolkit = "find_cuda_toolkit",
-    _use_cpp_toolchain = "use_cpp_toolchain",
     _use_cuda_toolchain = "use_cuda_toolchain",
 )
 load("@rules_cuda//cuda/private:toolchain_config_lib.bzl", _config_helper = "config_helper")
 
 # create a struct to group toolchain symbols semantically
 toolchain = struct(
-    use_cpp_toolchain = _use_cpp_toolchain,
     use_cuda_toolchain = _use_cuda_toolchain,
     find_cuda_toolchain = _find_cuda_toolchain,
     find_cuda_toolkit = _find_cuda_toolkit,


### PR DESCRIPTION
This PR tries to use `use_cpp_toolchain` from `@bazel_tools` instead of the copied definition earlier.