### PR TITLE
feat: automatically detect compiler_executable from registered cc_toolchain

### DIFF
--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -198,6 +198,7 @@ def detect_clang(repository_ctx):
 
     The path to clang is determined by:
 
+      - taken from configured cc_toolchain if `CUDA_COMPILER_USE_CC_TOOLCHAIN` = "true"
       - taken from `CUDA_CLANG_LABEL` environment variable
       - taken from `CUDA_CLANG_PATH` environment variable
       - taken from `BAZEL_LLVM` environment variable as `$BAZEL_LLVM/bin/clang` or
@@ -211,6 +212,7 @@ def detect_clang(repository_ctx):
         clang_path_or_label (str | None): Optionally return a string of path or label to clang executable if detected.
     """
     bin_ext = ".exe" if _is_windows(repository_ctx) else ""
+
     clang_path = repository_ctx.os.environ.get("CUDA_CLANG_PATH", None)
     clang_label = repository_ctx.os.environ.get("CUDA_CLANG_LABEL", None)
     clang_path_or_label = None
@@ -251,8 +253,8 @@ def _cuda_toolkit_impl(repository_ctx):
     cuda = detect_cuda_toolkit(repository_ctx)
     config_cuda_toolkit_and_nvcc(repository_ctx, cuda)
 
-    clang_path = detect_clang(repository_ctx)
-    config_clang(repository_ctx, cuda, clang_path)
+    clang_path_or_label = detect_clang(repository_ctx)
+    config_clang(repository_ctx, cuda, clang_path_or_label)
 
     config_disabled(repository_ctx)
 
@@ -271,7 +273,7 @@ cuda_toolkit = repository_rule(
     },
     configure = True,
     local = True,
-    environ = ["CUDA_PATH", "PATH", "CUDA_CLANG_PATH", "BAZEL_LLVM"],
+    environ = ["CUDA_PATH", "PATH", "CUDA_CLANG_PATH", "CUDA_CLANG_LABEL", "BAZEL_LLVM", "CUDA_COMPILER_USE_CC_TOOLCHAIN"],
     # remotable = True,
 )
 

--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -214,22 +214,25 @@ def detect_clang(repository_ctx):
     clang_path = repository_ctx.os.environ.get("CUDA_CLANG_PATH", None)
     clang_label = repository_ctx.os.environ.get("CUDA_CLANG_LABEL", None)
     clang_path_or_label = None
-    
-    # Check CUDA_CLANG_LABEL first
+
     if clang_label != None:
+        # Check CUDA_CLANG_LABEL first
         clang_path_or_label = clang_label
-    # Check CUDA_CLANG_PATH next
+
     elif clang_path != None and repository_ctx.path(clang_path).exists:
+        # Check CUDA_CLANG_PATH next
         clang_path_or_label = clang_path
-    # Check BAZEL_LLVM
+
     else:
+        # Check BAZEL_LLVM
         bazel_llvm = repository_ctx.os.environ.get("BAZEL_LLVM", None)
         if bazel_llvm != None and repository_ctx.path(bazel_llvm + "/bin/clang" + bin_ext).exists:
             clang_path_or_label = bazel_llvm + "/bin/clang" + bin_ext
-        # Finally try 'which clang'
+            # Finally try 'which clang'
+
         elif repository_ctx.which("clang") != None:
             clang_path_or_label = str(repository_ctx.which("clang"))
-    
+
     return clang_path_or_label
 
 def config_clang(repository_ctx, cuda, clang_path_or_label):

--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -224,7 +224,7 @@ def detect_clang(repository_ctx):
     if clang_path_or_label == None:
         clang_path_or_label = str(repository_ctx.which("clang"))
 
-    if clang_path_or_label != None and not repository_ctx.path(clang_path).exists:
+    if clang_path_or_label != None and (not clang_path or not repository_ctx.path(clang_path).exists):
         clang_path_or_label = None
 
     return clang_path

--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -216,7 +216,7 @@ def detect_clang(repository_ctx):
     clang_path_or_label = None
     if clang_path == None and clang_label != None:
         clang_path_or_label = clang_label
-    
+
     if clang_path == None:
         bazel_llvm = repository_ctx.os.environ.get("BAZEL_LLVM", None)
         if bazel_llvm != None and repository_ctx.path(bazel_llvm + "/bin/clang" + bin_ext).exists:
@@ -226,7 +226,6 @@ def detect_clang(repository_ctx):
 
     if clang_path_or_label != None and not repository_ctx.path(clang_path).exists:
         clang_path_or_label = None
-    
 
     return clang_path
 

--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -228,9 +228,8 @@ def detect_clang(repository_ctx):
         bazel_llvm = repository_ctx.os.environ.get("BAZEL_LLVM", None)
         if bazel_llvm != None and repository_ctx.path(bazel_llvm + "/bin/clang" + bin_ext).exists:
             clang_path_or_label = bazel_llvm + "/bin/clang" + bin_ext
-            # Finally try 'which clang'
-
         elif repository_ctx.which("clang") != None:
+            # Finally try 'which clang'
             clang_path_or_label = str(repository_ctx.which("clang"))
 
     return clang_path_or_label

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -163,7 +163,7 @@ def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
     clang_path_for_subst = ""
     clang_label_for_subst = ""
 
-    compiler_use_cc_toolchain_env = repository_ctx.getenv("CUDA_COMPILER_USE_CC_TOOLCHAIN", "false")
+    compiler_use_cc_toolchain_env = repository_ctx.os.environ.get("CUDA_COMPILER_USE_CC_TOOLCHAIN", "false")
     if compiler_use_cc_toolchain_env == "true":
         compiler_attr_line = "compiler_use_cc_toolchain = True,"
     elif clang_path_or_label.startswith("//") or clang_path_or_label.startswith("@"):

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -192,10 +192,9 @@ def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
         "%{fatbinary_label}": cuda.fatbinary_label,
     }
 
-    # Now remove the unused specific placeholder IF it's not needed by compiler_attribute_line
-    if clang_label_for_subst:  # We used compiler_label
+    if clang_label_for_subst:
         substitutions.pop("%{clang_path}")
-    if clang_path_for_subst:  # We used compiler_executable
+    if clang_path_for_subst:
         substitutions.pop("%{clang_label}")
 
     repository_ctx.template(

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -159,7 +159,7 @@ def _generate_toolchain_build(repository_ctx, cuda):
 
 def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
     tpl_label = Label("//cuda/private:templates/BUILD.toolchain_clang")
-    
+
     if clang_path_or_label.startswith("//") or not clang_path_or_label.startswith("@"):
         compiler_executable_or_label = "compiler_label"
     else:

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -159,15 +159,17 @@ def _generate_toolchain_build(repository_ctx, cuda):
 
 def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
     tpl_label = Label("//cuda/private:templates/BUILD.toolchain_clang")
-
-    if clang_path_or_label.startswith("//") or clang_path_or_label.startswith("@"):
-        compiler_executable_or_label = "compiler_label"
+    clang_path = ""
+    clang_label = ""
+    if clang_path_or_label.startswith("//") or not clang_path_or_label.startswith("@"):
+        clang_label = clang_path_or_label
     else:
-        clang_path_or_label = _to_forward_slash(clang_path_or_label) if clang_path_or_label else "cuda-clang-path-not-found"
-        compiler_executable_or_label = "compiler_executable"
+        clang_label = ""
+        clang_path = _to_forward_slash(clang_path_or_label) if clang_path_or_label else "cuda-clang-path-not-found"
+
     substitutions = {
-        "%{compiler_executable_or_label}": compiler_executable_or_label,
-        "%{clang_path_or_label}": clang_path_or_label,
+        "%{clang_path}": clang_path,
+        "%{clang_label}": clang_label,
         "%{cuda_path}": _to_forward_slash(cuda.path) if cuda.path else "cuda-not-found",
         "%{cuda_version}": "{}.{}".format(cuda.version_major, cuda.version_minor),
         "%{nvcc_label}": cuda.nvcc_label,

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -160,7 +160,7 @@ def _generate_toolchain_build(repository_ctx, cuda):
 def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
     tpl_label = Label("//cuda/private:templates/BUILD.toolchain_clang")
 
-    if clang_path_or_label.startswith("//") or not clang_path_or_label.startswith("@"):
+    if clang_path_or_label.startswith("//") or clang_path_or_label.startswith("@"):
         compiler_executable_or_label = "compiler_label"
     else:
         clang_path_or_label = _to_forward_slash(clang_path_or_label) if clang_path_or_label else "cuda-clang-path-not-found"

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -161,7 +161,7 @@ def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
     tpl_label = Label("//cuda/private:templates/BUILD.toolchain_clang")
     clang_path = ""
     clang_label = ""
-    if clang_path_or_label.startswith("//") or not clang_path_or_label.startswith("@"):
+    if clang_path_or_label.startswith("//") or clang_path_or_label.startswith("@"):
         clang_label = clang_path_or_label
     else:
         clang_label = ""

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -157,10 +157,17 @@ def _generate_toolchain_build(repository_ctx, cuda):
         substitutions["%{env_tmp}"] = _to_forward_slash(env_tmp)
     repository_ctx.template("toolchain/BUILD", tpl_label, substitutions = substitutions, executable = False)
 
-def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path):
+def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
     tpl_label = Label("//cuda/private:templates/BUILD.toolchain_clang")
+    
+    if clang_path_or_label.startswith("//") or not clang_path_or_label.startswith("@"):
+        compiler_executable_or_label = "compiler_label"
+    else:
+        clang_path_or_label = _to_forward_slash(clang_path_or_label) if clang_path_or_label else "cuda-clang-path-not-found"
+        compiler_executable_or_label = "compiler_executable"
     substitutions = {
-        "%{clang_path}": _to_forward_slash(clang_path) if clang_path else "cuda-clang-not-found",
+        "%{compiler_executable_or_label}": compiler_executable_or_label,
+        "%{clang_path_or_label}": clang_path_or_label,
         "%{cuda_path}": _to_forward_slash(cuda.path) if cuda.path else "cuda-not-found",
         "%{cuda_version}": "{}.{}".format(cuda.version_major, cuda.version_minor),
         "%{nvcc_label}": cuda.nvcc_label,

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -163,17 +163,18 @@ def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
     clang_path_for_subst = ""
     clang_label_for_subst = ""
 
-    if clang_path_or_label.startswith("//") or clang_path_or_label.startswith("@"):
+    compiler_use_cc_toolchain_env = repository_ctx.getenv("CUDA_COMPILER_USE_CC_TOOLCHAIN", "false")
+    if compiler_use_cc_toolchain_env == "true":
+        compiler_attr_line = "compiler_use_cc_toolchain = True,"
+    elif clang_path_or_label.startswith("//") or clang_path_or_label.startswith("@"):
         # Use compiler_label
-        compiler_attr_line = 'compiler_label = "%{{clang_label}}",'  # Note the double braces {{}} to escape for format
+        compiler_attr_line = 'compiler_label = "%{{clang_label}}",'
         clang_label_for_subst = clang_path_or_label
     else:
         # Use compiler_executable
-        compiler_attr_line = 'compiler_executable = "%{{clang_path}}",'  # Note the double braces {{}}
+        compiler_attr_line = 'compiler_executable = "%{{clang_path}}",'
         clang_path_for_subst = _to_forward_slash(clang_path_or_label) if clang_path_or_label else "cuda-clang-path-not-found"
 
-    # Use .format() first to insert the correct placeholder name into the line
-    # This makes the substitutions dictionary simpler later.
     compiler_attr_line = compiler_attr_line.format(
         clang_label = "%{clang_label}",
         clang_path = "%{clang_path}",

--- a/cuda/private/templates/BUILD.toolchain_clang
+++ b/cuda/private/templates/BUILD.toolchain_clang
@@ -25,8 +25,9 @@ cuda_toolchain_config(
 
 cuda_toolchain(
     name = "clang-local",
-    %{compiler_executable_or_label} = "%{clang_path_or_label}",
+    compiler_executable = "%{clang_path}",
     compiler_files = "@cuda//:compiler_deps",
+    compiler_label = "%{clang_label}",
     toolchain_config = ":clang-local-config",
 )
 

--- a/cuda/private/templates/BUILD.toolchain_clang
+++ b/cuda/private/templates/BUILD.toolchain_clang
@@ -25,9 +25,8 @@ cuda_toolchain_config(
 
 cuda_toolchain(
     name = "clang-local",
-    compiler_executable = "%{clang_path}",
+    # %{compiler_attribute_line}
     compiler_files = "@cuda//:compiler_deps",
-    compiler_label = "%{clang_label}",
     toolchain_config = ":clang-local-config",
 )
 

--- a/cuda/private/templates/BUILD.toolchain_clang
+++ b/cuda/private/templates/BUILD.toolchain_clang
@@ -25,7 +25,7 @@ cuda_toolchain_config(
 
 cuda_toolchain(
     name = "clang-local",
-    compiler_executable = "%{clang_path}",
+    %{compiler_executable_or_label} = "%{clang_path_or_label}",
     compiler_files = "@cuda//:compiler_deps",
     toolchain_config = ":clang-local-config",
 )

--- a/cuda/private/toolchain.bzl
+++ b/cuda/private/toolchain.bzl
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
 load("//cuda/private:providers.bzl", "CudaToolchainConfigInfo", "CudaToolkitInfo")
 load("//cuda/private:toolchain_config_lib.bzl", "config_helper")
 
@@ -70,6 +70,7 @@ def _cuda_toolchain_impl(ctx):
 cuda_toolchain = rule(
     doc = """This rule consumes a `CudaToolchainConfigInfo` and provides a `platform_common.ToolchainInfo`, a.k.a, the CUDA Toolchain.""",
     implementation = _cuda_toolchain_impl,
+    toolchains = use_cpp_toolchain(),
     attrs = {
         "toolchain_config": attr.label(
             mandatory = True,
@@ -80,7 +81,7 @@ cuda_toolchain = rule(
         "compiler_executable": attr.string(doc = "The path of the main executable of this toolchain. Either compiler_executable or compiler_label must be specified if compiler_use_cc_toolchain is not set."),
         "compiler_label": attr.label(allow_single_file = True, executable = True, cfg = "exec", doc = "The label of the main executable of this toolchain. Either compiler_executable or compiler_label must be specified."),
         "compiler_files": attr.label(allow_files = True, cfg = "exec", doc = "The set of files that are needed when compiling using this toolchain."),
-        "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
+        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
     },
 )
 

--- a/cuda/private/toolchain.bzl
+++ b/cuda/private/toolchain.bzl
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
+load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("//cuda/private:providers.bzl", "CudaToolchainConfigInfo", "CudaToolkitInfo")
 load("//cuda/private:toolchain_config_lib.bzl", "config_helper")
 
@@ -21,7 +21,8 @@ def _cuda_toolchain_impl(ctx):
             compiler_executable = cc_toolchain.compiler_executable
         else:
             fail("compiler_use_cc_toolchain set to True but cannot find a configured cc_toolchain")
-    # Next, check for compiler_executable or compiler_label
+
+        # Next, check for compiler_executable or compiler_label
     elif has_compiler_executable:
         compiler_executable = ctx.attr.compiler_executable
     elif has_compiler_label:

--- a/cuda/private/toolchain.bzl
+++ b/cuda/private/toolchain.bzl
@@ -49,7 +49,6 @@ cuda_toolchain = rule(
         "compiler_files": attr.label(allow_files = True, cfg = "exec", doc = "The set of files that are needed when compiling using this toolchain."),
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
     },
-    toolchains = use_cpp_toolchain(),
 )
 
 CUDA_TOOLCHAIN_TYPE = "//cuda:toolchain_type"

--- a/cuda/private/toolchain.bzl
+++ b/cuda/private/toolchain.bzl
@@ -12,7 +12,7 @@ def _cuda_toolchain_impl(ctx):
     # compiler_use_cc_toolchain should be used alone and not along with compiler_executable or compiler_label
     if (ctx.attr.compiler_use_cc_toolchain == True) and (has_compiler_executable or has_compiler_label):
         fail("compiler_use_cc_toolchain set to True but compiler_executable or compiler_label also set.")
-    elif (not has_compiler_executable) and (not has_compiler_label):
+    elif (ctx.attr.compiler_use_cc_toolchain == False) and not has_compiler_executable and not has_compiler_label:
         fail("Either compiler_executable or compiler_label must be specified or if a valid cc_toolchain is registered, set attr compiler_use_cc_toolchain to True.")
 
     # First, attempt to use configured cc_toolchain if attr compiler_use_cc_toolchain set.

--- a/cuda/private/toolchain.bzl
+++ b/cuda/private/toolchain.bzl
@@ -15,7 +15,7 @@ def _cuda_toolchain_impl(ctx):
     elif has_compiler_label:
         l = ctx.attr.compiler_label.label
         compiler_executable = "{}/{}/{}".format(l.workspace_root, l.package, l.name)
-    
+
     if (ctx.attr.compiler_executable == "cuda-clang-not-found" or ctx.attr.compiler_executable.startswith("/")) and has_cc_toolchain:
         compiler_executable = cc_toolchain.compiler_executable
 

--- a/cuda/private/toolchain.bzl
+++ b/cuda/private/toolchain.bzl
@@ -55,7 +55,6 @@ cuda_toolchain = rule(
         "compiler_files": attr.label(allow_files = True, cfg = "exec", doc = "The set of files that are needed when compiling using this toolchain."),
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
     },
-    toolchains = use_cpp_toolchain(),
 )
 
 CUDA_TOOLCHAIN_TYPE = "//cuda:toolchain_type"

--- a/cuda/private/toolchain.bzl
+++ b/cuda/private/toolchain.bzl
@@ -21,8 +21,6 @@ def _cuda_toolchain_impl(ctx):
             compiler_executable = cc_toolchain.compiler_executable
         else:
             fail("compiler_use_cc_toolchain set to True but cannot find a configured cc_toolchain")
-
-        # Next, check for compiler_executable or compiler_label
     elif has_compiler_executable:
         compiler_executable = ctx.attr.compiler_executable
     elif has_compiler_label:
@@ -40,15 +38,16 @@ def _cuda_toolchain_impl(ctx):
     for pattern in cuda_toolchain_config.artifact_name_patterns:
         artifact_name_patterns[pattern.category_name] = pattern
 
+    # construct compiler_depset
     compiler_depset = depset()
     if ctx.attr.compiler_use_cc_toolchain:
-        compiler_depset = cc_toolchain.all_files
+        compiler_depset = cc_toolchain.all_files  # pass all cc_toolchain to toolchain_files
     elif has_compiler_executable:
         pass
     elif has_compiler_label:
         compiler_target_info = ctx.attr.compiler_label[DefaultInfo]
         if not compiler_target_info.files_to_run or not compiler_target_info.files_to_run.executable:
-            fail("Not an executable")
+            fail("compiler_label specified is not an executable, specify a valid compiler_label")
         compiler_depset = depset(direct = [compiler_target_info.files_to_run.executable], transitive = [compiler_target_info.default_runfiles.files])
 
     toolchain_files = depset(transitive = [

--- a/cuda/private/toolchain.bzl
+++ b/cuda/private/toolchain.bzl
@@ -49,6 +49,7 @@ cuda_toolchain = rule(
         "compiler_files": attr.label(allow_files = True, cfg = "exec", doc = "The set of files that are needed when compiling using this toolchain."),
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
     },
+    toolchains = use_cpp_toolchain(),
 )
 
 CUDA_TOOLCHAIN_TYPE = "//cuda:toolchain_type"

--- a/cuda/private/toolchain.bzl
+++ b/cuda/private/toolchain.bzl
@@ -12,7 +12,7 @@ def _cuda_toolchain_impl(ctx):
     # compiler_use_cc_toolchain should be used alone and not along with compiler_executable or compiler_label
     if (ctx.attr.compiler_use_cc_toolchain == True) and (has_compiler_executable or has_compiler_label):
         fail("compiler_use_cc_toolchain set to True but compiler_executable or compiler_label also set.")
-    elif (not has_compiler_executable) or (not has_compiler_label):
+    elif (not has_compiler_executable) and (not has_compiler_label):
         fail("Either compiler_executable or compiler_label must be specified or if a valid cc_toolchain is registered, set attr compiler_use_cc_toolchain to True.")
 
     # First, attempt to use configured cc_toolchain if attr compiler_use_cc_toolchain set.


### PR DESCRIPTION
When a compatible `cc_toolchain` is registered, prefer that when compiler_executable is not set or set to non-hermetic system executable.

### Why?
With this PR's change, I was able to just make my pre-configured `toolchains_llvm`-based toolchain be automatically selected. Without this, I had to fully specifiy my own local toolchain with a `compiler_executable` pointing to the llvm_toolchain's clang binary.

After #330 

Fixes #324 

TODO:

- [x] Create `compiler_use_cc_toolchain` flag to set the value to true while generating the BUILD file
- [ ] Add an integration test using this feature