### PR TITLE
Add CcInfo external_includes

### DIFF
--- a/cuda/private/cuda_helper.bzl
+++ b/cuda/private/cuda_helper.bzl
@@ -256,6 +256,7 @@ def _create_common(ctx):
     for inc in attr.includes:
         system_includes.extend(_resolve_includes(ctx, inc))
     system_includes.extend(merged_cc_info.compilation_context.system_includes.to_list())
+    system_includes.extend(merged_cc_info.compilation_context.external_includes.to_list())
     quote_includes.extend(merged_cc_info.compilation_context.quote_includes.to_list())
 
     # gather header info

--- a/cuda/private/cuda_helper.bzl
+++ b/cuda/private/cuda_helper.bzl
@@ -256,7 +256,7 @@ def _create_common(ctx):
     for inc in attr.includes:
         system_includes.extend(_resolve_includes(ctx, inc))
     system_includes.extend(merged_cc_info.compilation_context.system_includes.to_list())
-    system_includes.extend(merged_cc_info.compilation_context.external_includes.to_list())
+    system_includes.extend(getattr(merged_cc_info.compilation_context, "external_includes", depset()).to_list())
     quote_includes.extend(merged_cc_info.compilation_context.quote_includes.to_list())
 
     # gather header info


### PR DESCRIPTION
These are set if your `cuda_library` depends on a `cc_library` that is
part of another bazel module besides the main one and you set
`--features=external_include_paths`

We could thread these through with a different variable but they end up
being treated the same so I don't think it matters.
