### PR TITLE
fix(nvcc): append to `cpp_compile` `PATH`

### DIFF
--- a/cuda/private/toolchain_configs/nvcc.bzl
+++ b/cuda/private/toolchain_configs/nvcc.bzl
@@ -63,8 +63,14 @@ def _impl(ctx):
         variables = c_compile_variables,
     )
 
-    # We know we are linux here, so ":" should be save.
-    path = ":".join([env.get("PATH", ""), paths.dirname(host_compiler)])
+    components = [
+        env.get("PATH"),
+        paths.dirname(host_compiler),
+        ctx.configuration.default_shell_env.get("PATH"),
+    ]
+    path = ctx.configuration.host_path_separator.join(
+        [c for c in components if c],
+    )
 
     nvcc_compile_env_feature = feature(
         name = "nvcc_compile_env",


### PR DESCRIPTION
This is a follow-up to #323

In cases where the compiler is a wrapper script that depends on some tool in the bazel-default `PATH`, this should be available to the action execution.

Ordering here is important:
- toolchain-defined `PATH` takes precedence as `nvcc` should find find the compiler from that.
- after that the parent directory of the compiler. This is potentially already part of the first component.
- at the end the usual `PATH`. This must come last to only be considered if nothing was found in the first two directories.