### PR TITLE
Fix MODULE example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ determains how the toolchains are detected.
 Add the following to your `MODULE.bazel` file and replace the placeholders with actual values.
 
 ```starlark
-bazel_dep(name = "rules_cuda", version = "0.2.1")
+bazel_dep(name = "rules_cuda", version = "0.2.4")
 
 # pick a specific version (this is optional an can be skipped)
 archive_override(
@@ -47,7 +47,7 @@ archive_override(
     strip_prefix = "rules_cuda-{git_commit_hash}",
 )
 
-cuda = use_extension("@rules_cuda//cuda:extensions.bzl", "toolchain")
+cuda = use_extension("@rules_cuda//cuda:extensions.bzl", "toolkit")
 cuda.toolkit(
     name = "local_cuda",
     toolkit_path = "",


### PR DESCRIPTION
The previous example in README failed with error:

```
ERROR: Analysis of target '//project_template/cpp:main' failed; build aborted: The module extension defined at /home/dev/.cache/bazel/_bazel_dev/0a671fc952be90f724e819c56b1dda7d/external/rules_cuda+/cuda/extensions.bzl:42:29 does not have a tag class named toolkit, but its use is attempted at /home/dev/llm/MODULE.bazel:4:13
```

we have to import toolkit instead of toolchain from cuda.

Also took the chance to bump rules_cuda.