### PR TITLE
Expand make variables in copts and host_copts

### DIFF
--- a/cuda/private/cuda_helper.bzl
+++ b/cuda/private/cuda_helper.bzl
@@ -276,13 +276,13 @@ def _create_common(ctx):
     # gather compile info
     defines = []
     local_defines = [i for i in attr.local_defines]
-    compile_flags = attr._default_cuda_copts[BuildSettingInfo].value + [o for o in attr.copts if _check_opts(o)]
+    compile_flags = attr._default_cuda_copts[BuildSettingInfo].value + [ctx.expand_make_variables("copts", o, {}) for o in attr.copts if _check_opts(o)]
     link_flags = []
     if hasattr(attr, "linkopts"):
         link_flags.extend([o for o in attr.linkopts if _check_opts(o)])
     host_defines = []
     host_local_defines = [i for i in attr.host_local_defines]
-    host_compile_flags = attr._default_host_copts[BuildSettingInfo].value + [i for i in attr.host_copts]
+    host_compile_flags = attr._default_host_copts[BuildSettingInfo].value + [ctx.expand_make_variables("host_copts", i) for i in attr.host_copts]
     host_link_flags = []
     if hasattr(attr, "host_linkopts"):
         host_link_flags.extend([i for i in attr.host_linkopts])


### PR DESCRIPTION
This mirrors behavior of rules_cc enabling things like `-I$(GENDIR)/external/foo` for when you need to reference a generated header.