### PR TITLE
Update deprecated CI runners

### DIFF
--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       matrix:
         cases:
-          - { os: "ubuntu-20.04", cuda-version: "11.2.2", source: "nvidia" }
+          - { os: "ubuntu-22.04", cuda-version: "11.2.2", source: "nvidia" }
           - { os: "ubuntu-22.04", cuda-version: "11.8.0", source: "nvidia" }
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-22.04",
               cuda-version: "11.6.2",
               source: "nvidia",
               toolchain: "llvm",

--- a/.github/workflows/build-tests.yaml
+++ b/.github/workflows/build-tests.yaml
@@ -14,11 +14,11 @@ jobs:
     strategy:
       matrix:
         cases:
-          - { os: "ubuntu-22.04", cuda-version: "11.2.2", source: "nvidia" }
+          - { os: "ubuntu-22.04", cuda-version: "11.7.0", source: "nvidia" }
           - { os: "ubuntu-22.04", cuda-version: "11.8.0", source: "nvidia" }
           - {
               os: "ubuntu-22.04",
-              cuda-version: "11.6.2",
+              cuda-version: "11.7.0",
               source: "nvidia",
               toolchain: "llvm",
               toolchain-version: "16",

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -15,13 +15,13 @@ jobs:
       matrix:
         cases:
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-22.04",
               cuda-version: "11.6.2",
               source: "nvidia",
               toolchain: "nvcc",
             }
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-22.04",
               cuda-version: "11.6.2",
               source: "nvidia",
               toolchain: "llvm",
@@ -82,13 +82,13 @@ jobs:
       matrix:
         cases:
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-22.04",
               cuda-version: "11.6.2",
               source: "nvidia",
               toolchain: "nvcc",
             }
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-22.04",
               cuda-version: "11.6.2",
               source: "nvidia",
               toolchain: "llvm",

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -16,13 +16,13 @@ jobs:
         cases:
           - {
               os: "ubuntu-22.04",
-              cuda-version: "11.6.2",
+              cuda-version: "11.7.0",
               source: "nvidia",
               toolchain: "nvcc",
             }
           - {
               os: "ubuntu-22.04",
-              cuda-version: "11.6.2",
+              cuda-version: "11.7.0",
               source: "nvidia",
               toolchain: "llvm",
               toolchain-version: "16",
@@ -83,13 +83,13 @@ jobs:
         cases:
           - {
               os: "ubuntu-22.04",
-              cuda-version: "11.6.2",
+              cuda-version: "11.7.0",
               source: "nvidia",
               toolchain: "nvcc",
             }
           - {
               os: "ubuntu-22.04",
-              cuda-version: "11.6.2",
+              cuda-version: "11.7.0",
               source: "nvidia",
               toolchain: "llvm",
               toolchain-version: "16",

--- a/.github/workflows/utilities-tests.yaml
+++ b/.github/workflows/utilities-tests.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - windows-2019
         bazel-version:
           # NOTE: read from .bazelversion so that we don't randomly break our

--- a/.github/workflows/utilities-tests.yaml
+++ b/.github/workflows/utilities-tests.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: Jimver/cuda-toolkit@v0.2.22
         with:
-          cuda: 11.6.2
+          cuda: 11.7.0
           sub-packages: '["cudart"]'
           method: network
 


### PR DESCRIPTION
Account for deprecation of `ubuntu-20.04`
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/