### PR TITLE
feat: hermetic CUDA clang support 

### DIFF
--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -236,11 +236,6 @@ def detect_clang(repository_ctx):
 
     return clang_path_or_label
 
-<<<<<<< HEAD
-def config_clang(repository_ctx, cuda, clang_path_or_label):
-=======
-    return clang_path
-
 def generate_version_json(repository_ctx):
     """Generates the version.json file."""
     version_data = {
@@ -284,8 +279,8 @@ filegroup(
 """
     build_file_path = repository_ctx.path("clang/BUILD")
     repository_ctx.file(build_file_path, content = build_file_contents, executable = False)
-def config_clang(repository_ctx, cuda, clang_path):
->>>>>>> 7501b76 (clang cuda path working)
+
+def config_clang(repository_ctx, cuda, clang_path_or_label):
     """Generate `@cuda//toolchain/clang/BUILD`
 
     Args:
@@ -293,13 +288,11 @@ def config_clang(repository_ctx, cuda, clang_path):
         cuda: The struct returned from `detect_cuda_toolkit`
         clang_path_or_label: Path or label to clang executable returned from `detect_clang`
     """
-<<<<<<< HEAD
-    template_helper.generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label)
-=======
     is_local_ctk = None
 
     if len(repository_ctx.attr.components_mapping) != 0:
         is_local_ctk = False
+
     # for deliverable ctk, clang needs the toolkit as cuda_path
     if not is_local_ctk:
         nvcc_repo = components_mapping_compat.repo_str(repository_ctx.attr.components_mapping["nvcc"])
@@ -326,12 +319,10 @@ def config_clang(repository_ctx, cuda, clang_path):
         for source_path in source_paths:
             # executes only in analysis phase, need to declare as action
             repository_ctx.execute(["cp", "-r", str(source_path), clang_cuda_path])
-        
         generate_build(repository_ctx)
 
     # Generate @local_cuda//toolchain/clang/BUILD
-    template_helper.generate_toolchain_clang_build(repository_ctx, cuda, clang_path)
->>>>>>> 7501b76 (clang cuda path working)
+    template_helper.generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label)
 
 def config_disabled(repository_ctx):
     repository_ctx.symlink(Label("//cuda/private:templates/BUILD.toolchain_disabled"), "toolchain/disabled/BUILD")

--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -300,7 +300,6 @@ def config_clang(repository_ctx, cuda, clang_path):
 
     if len(repository_ctx.attr.components_mapping) != 0:
         is_local_ctk = False
-    print("debug!")
     # for deliverable ctk, clang needs the toolkit as cuda_path
     if not is_local_ctk:
         nvcc_repo = components_mapping_compat.repo_str(repository_ctx.attr.components_mapping["nvcc"])

--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -26,7 +26,7 @@ def _get_nvcc_version(repository_ctx, nvcc_root):
             return version[:2]
     return [-1, -1]
 
-def _detect_cuda_toolkit(repository_ctx):
+def _detect_local_cuda_toolkit(repository_ctx):
     cuda_path = repository_ctx.attr.toolkit_path
     if cuda_path == "":
         cuda_path = repository_ctx.os.environ.get("CUDA_PATH", None)
@@ -145,7 +145,7 @@ def detect_cuda_toolkit(repository_ctx):
     if repository_ctx.attr.components_mapping != {}:
         return _detect_deliverable_cuda_toolkit(repository_ctx)
     else:
-        return _detect_cuda_toolkit(repository_ctx)
+        return _detect_local_cuda_toolkit(repository_ctx)
 
 def config_cuda_toolkit_and_nvcc(repository_ctx, cuda):
     """Generate `@cuda//BUILD` and `@cuda//defs.bzl` and `@cuda//toolchain/BUILD`
@@ -236,49 +236,9 @@ def detect_clang(repository_ctx):
 
     return clang_path_or_label
 
-def generate_version_json(repository_ctx):
-    """Generates the version.json file."""
-    version_data = {
-        "cuda": {
-            "name": "CUDA SDK",
-            "version": "12.3.2",
-        },
-        "cuda_cccl": {
-            "name": "CUDA C++ Core Compute Libraries",
-            "version": "12.3.101",
-        },
-        "cuda_cudart": {
-            "name": "CUDA Runtime (cudart)",
-            "version": "12.3.101",
-        },
-        "cuda_nvcc": {
-            "name": "CUDA NVCC",
-            "version": "12.3.107",
-        },
-        "libcurand": {
-            "name": "CUDA cuRAND",
-            "version": "10.3.4.107",
-        },
-    }
-
-    json_string = json.encode(version_data)
-    version_json_path = repository_ctx.path("clang/version.json")
-    repository_ctx.file(version_json_path, content = json_string, executable = False)
-
-    version_txt_path = repository_ctx.path("clang/version.txt")
-    version_txt_content = "CUDA Version 12.3.2"
-    repository_ctx.file(version_txt_path, content = version_txt_content, executable = False)
-
 def generate_build(repository_ctx):
-    build_file_contents = """
-filegroup(
-    name = "cuda-files",
-    srcs = glob(["**"]),
-    visibility = ["//visibility:public"],
-)
-"""
-    build_file_path = repository_ctx.path("clang/BUILD")
-    repository_ctx.file(build_file_path, content = build_file_contents, executable = False)
+    tpl_label = Label("//cuda/private:templates/BUILD.clang_compiler_deps")
+    repository_ctx.template("clang_compiler_deps/BUILD", tpl_label, executable = False)
 
 def config_clang(repository_ctx, cuda, clang_path_or_label):
     """Generate `@cuda//toolchain/clang/BUILD`
@@ -288,7 +248,7 @@ def config_clang(repository_ctx, cuda, clang_path_or_label):
         cuda: The struct returned from `detect_cuda_toolkit`
         clang_path_or_label: Path or label to clang executable returned from `detect_clang`
     """
-    is_local_ctk = None
+    is_local_ctk = True
 
     if len(repository_ctx.attr.components_mapping) != 0:
         is_local_ctk = False
@@ -299,20 +259,17 @@ def config_clang(repository_ctx, cuda, clang_path_or_label):
         cudart_repo = components_mapping_compat.repo_str(repository_ctx.attr.components_mapping["cudart"])
         cccl_repo = components_mapping_compat.repo_str(repository_ctx.attr.components_mapping["cccl"])
 
-        libpath = "lib"  # any special logic for linux/windows difference?
-        generate_version_json(repository_ctx)
-
-        clang_cuda_path = repository_ctx.path("clang")
-        repository_ctx.execute(["mkdir", "-p", "clang"])
+        clang_cuda_path = repository_ctx.path("clang_compiler_deps")
+        repository_ctx.execute(["mkdir", "-p", "clang_compiler_deps"])
 
         source_paths = [
             repository_ctx.path(Label(nvcc_repo + "//:nvcc/bin")),
             repository_ctx.path(Label(nvcc_repo + "//:nvcc/include")),
             repository_ctx.path(Label(cudart_repo + "//:cudart/include")),
             repository_ctx.path(Label(cccl_repo + "//:cccl/include")),
-            repository_ctx.path(Label(nvcc_repo + "//:nvcc/" + libpath)),
-            repository_ctx.path(Label(cudart_repo + "//:cudart/" + libpath)),
-            repository_ctx.path(Label(cccl_repo + "//:cccl/" + libpath)),
+            repository_ctx.path(Label(nvcc_repo + "//:nvcc/lib")),
+            repository_ctx.path(Label(cudart_repo + "//:cudart/lib")),
+            repository_ctx.path(Label(cccl_repo + "//:cccl/lib")),
             repository_ctx.path(Label(nvcc_repo + "//:nvcc/nvvm")),
         ]
 

--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -26,7 +26,7 @@ def _get_nvcc_version(repository_ctx, nvcc_root):
             return version[:2]
     return [-1, -1]
 
-def _detect_local_cuda_toolkit(repository_ctx):
+def _detect_cuda_toolkit(repository_ctx):
     cuda_path = repository_ctx.attr.toolkit_path
     if cuda_path == "":
         cuda_path = repository_ctx.os.environ.get("CUDA_PATH", None)
@@ -145,7 +145,7 @@ def detect_cuda_toolkit(repository_ctx):
     if repository_ctx.attr.components_mapping != {}:
         return _detect_deliverable_cuda_toolkit(repository_ctx)
     else:
-        return _detect_local_cuda_toolkit(repository_ctx)
+        return _detect_cuda_toolkit(repository_ctx)
 
 def config_cuda_toolkit_and_nvcc(repository_ctx, cuda):
     """Generate `@cuda//BUILD` and `@cuda//defs.bzl` and `@cuda//toolchain/BUILD`
@@ -321,7 +321,7 @@ def config_clang(repository_ctx, cuda, clang_path_or_label):
             repository_ctx.execute(["cp", "-r", str(source_path), clang_cuda_path])
         generate_build(repository_ctx)
 
-    # Generate @local_cuda//toolchain/clang/BUILD
+    # Generate @cuda//toolchain/clang/BUILD
     template_helper.generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label)
 
 def config_disabled(repository_ctx):

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -184,7 +184,7 @@ def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
         "# %{compiler_attribute_line}": compiler_attr_line,
         "%{clang_path}": clang_path_for_subst,  # Will be empty if label is used
         "%{clang_label}": clang_label_for_subst,  # Will be empty if path is used
-        "%{cuda_path}": _to_forward_slash(cuda.path) if cuda.path else "cuda-not-found",
+        "%{cuda_path}": _to_forward_slash(cuda.path) if cuda.path else "external/rules_cuda++toolchain+cuda/clang",
         "%{cuda_version}": "{}.{}".format(cuda.version_major, cuda.version_minor),
         "%{nvcc_label}": cuda.nvcc_label,
         "%{nvlink_label}": cuda.nvlink_label,

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -184,8 +184,7 @@ def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
     if cuda.path:
         cuda_path_for_subst = _to_forward_slash(cuda.path)
     else:
-        # Use repository_ctx.name to get the correct canonical name
-        cuda_path_for_subst = "external/{}/clang_compiler_deps".format(repository_ctx.name)
+        cuda_path_for_subst = "{}/clang_compiler_deps".format(Label("@cuda//cuda").workspace_root)
 
     substitutions = {
         "# %{compiler_attribute_line}": compiler_attr_line,

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -180,12 +180,19 @@ def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
         clang_path = "%{clang_path}",
     )
 
+    cuda_path_for_subst = ""
+    if cuda.path:
+        cuda_path_for_subst = _to_forward_slash(cuda.path)
+    else:
+        # Use repository_ctx.name to get the correct canonical name
+        cuda_path_for_subst = "external/{}/clang_compiler_deps".format(repository_ctx.name)
+
     substitutions = {
         "# %{compiler_attribute_line}": compiler_attr_line,
         "%{clang_compiler_files}": "@cuda//:compiler_deps" if cuda.path else "@cuda//clang_compiler_deps",
         "%{clang_path}": clang_path_for_subst,  # Will be empty if label is used
         "%{clang_label}": clang_label_for_subst,  # Will be empty if path is used
-        "%{cuda_path}": _to_forward_slash(cuda.path) if cuda.path else "external/rules_cuda++toolchain+cuda/clang_compiler_deps",  # needs to be relative to work in RBE.
+        "%{cuda_path}": cuda_path_for_subst,
         "%{cuda_version}": "{}.{}".format(cuda.version_major, cuda.version_minor),
         "%{nvcc_label}": cuda.nvcc_label,
         "%{nvlink_label}": cuda.nvlink_label,

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -182,9 +182,10 @@ def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
 
     substitutions = {
         "# %{compiler_attribute_line}": compiler_attr_line,
+        "%{clang_compiler_files}": "@cuda//:compiler_deps" if cuda.path else "@cuda//clang_compiler_deps",
         "%{clang_path}": clang_path_for_subst,  # Will be empty if label is used
         "%{clang_label}": clang_label_for_subst,  # Will be empty if path is used
-        "%{cuda_path}": _to_forward_slash(cuda.path) if cuda.path else "external/rules_cuda++toolchain+cuda/clang",
+        "%{cuda_path}": _to_forward_slash(cuda.path) if cuda.path else "external/rules_cuda++toolchain+cuda/clang_compiler_deps",  # needs to be relative to work in RBE.
         "%{cuda_version}": "{}.{}".format(cuda.version_major, cuda.version_minor),
         "%{nvcc_label}": cuda.nvcc_label,
         "%{nvlink_label}": cuda.nvlink_label,

--- a/cuda/private/templates/BUILD.clang_compiler_deps
+++ b/cuda/private/templates/BUILD.clang_compiler_deps
@@ -1,0 +1,12 @@
+# clang needs these files at a single location and be passed as `cuda-path` arg.
+# These include, lib, bin, nvvm files are collected from cccl, nvvm, nvcc, cudart in cuda/private/repositories.bzl
+filegroup(
+    name = "clang_compiler_deps",
+    srcs = glob([
+        "bin/**",
+        "include/**",
+        "lib/**",
+        "nvvm/**",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/cuda/private/templates/BUILD.toolchain_clang
+++ b/cuda/private/templates/BUILD.toolchain_clang
@@ -25,8 +25,13 @@ cuda_toolchain_config(
 
 cuda_toolchain(
     name = "clang-local",
+<<<<<<< HEAD
     # %{compiler_attribute_line}
     compiler_files = "@cuda//:compiler_deps",
+=======
+    compiler_executable = "%{clang_path}",
+    compiler_files = "@local_cuda//clang:cuda-files",
+>>>>>>> 7501b76 (clang cuda path working)
     toolchain_config = ":clang-local-config",
 )
 

--- a/cuda/private/templates/BUILD.toolchain_clang
+++ b/cuda/private/templates/BUILD.toolchain_clang
@@ -26,7 +26,7 @@ cuda_toolchain_config(
 cuda_toolchain(
     name = "clang-local",
     # %{compiler_attribute_line}
-    compiler_files = "@cuda//clang:cuda-files",
+    compiler_files = "%{clang_compiler_files}",
     toolchain_config = ":clang-local-config",
 )
 

--- a/cuda/private/templates/BUILD.toolchain_clang
+++ b/cuda/private/templates/BUILD.toolchain_clang
@@ -25,13 +25,8 @@ cuda_toolchain_config(
 
 cuda_toolchain(
     name = "clang-local",
-<<<<<<< HEAD
     # %{compiler_attribute_line}
-    compiler_files = "@cuda//:compiler_deps",
-=======
-    compiler_executable = "%{clang_path}",
     compiler_files = "@local_cuda//clang:cuda-files",
->>>>>>> 7501b76 (clang cuda path working)
     toolchain_config = ":clang-local-config",
 )
 

--- a/cuda/private/templates/BUILD.toolchain_clang
+++ b/cuda/private/templates/BUILD.toolchain_clang
@@ -26,7 +26,7 @@ cuda_toolchain_config(
 cuda_toolchain(
     name = "clang-local",
     # %{compiler_attribute_line}
-    compiler_files = "@local_cuda//clang:cuda-files",
+    compiler_files = "@cuda//clang:cuda-files",
     toolchain_config = ":clang-local-config",
 )
 


### PR DESCRIPTION
Partially part of #283 

This PR adds the missing piece of hermetic CUDA compilation with clang. The provided `compiler_deps` repo (alias cuda_nvcc) wasn't enough for clang to infer everything from. Typically, it's documented in multiple places ([(1)](https://llvm.org/docs/CompileCudaWithLLVM.html#id3), [(2)](https://reviews.llvm.org/D42642)) that clang expects the entire CUDA toolkit and there is no recommended "minimal" CUDA setup. Nevertheless, I found that `cccl`, `nvcc`, `cudart`, `nvvm` components were enough.

Surprisingly, I didn't need the `version.json` or `version.txt` file anymore so I removed the logic to generate the root `version.json` file.

In `config_clang` we create a new folder called `clang_compiler_deps` where we collect `bin`, `lib`, `include` files from the required components and place in a single collected folder. 

We've been using this implementation for more than a month now with over 20+ `cuda_library` usages and `cc_test`s that run on NVIDIA GPU hermetically in RBE with CUDA 12.3 and LLVM 19.1.0

