### PR TITLE
feat: add nvcc_fixed_random_seed feature for nvcc based toolchain config

### DIFF
--- a/cuda/private/toolchain_configs/nvcc.bzl
+++ b/cuda/private/toolchain_configs/nvcc.bzl
@@ -559,6 +559,21 @@ def _impl(ctx):
         ],
     )
 
+    # NOTE: this only works on compiler newer than 12.9
+    nvcc_fixed_random_seed_feature = feature(
+        name = "nvcc_fixed_random_seed",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cuda_compile,
+                    ACTION_NAMES.device_link,
+                ],
+                flag_groups = [flag_group(flags = ["--frandom-seed=%{output_file}"])],
+            ),
+        ] if nvcc_version_ge(ctx, 12, 9) else [],
+    )
+
     cuda_device_debug_feature = feature(
         name = "cuda_device_debug",
         flag_sets = [
@@ -601,6 +616,7 @@ def _impl(ctx):
         nvcc_allow_unsupported_compiler_feature,
         nvcc_relaxed_constexpr_feature,
         nvcc_extended_lambda_feature,
+        nvcc_fixed_random_seed_feature,
         cuda_device_debug_feature,
     ]
 

--- a/cuda/private/toolchain_configs/nvcc_msvc.bzl
+++ b/cuda/private/toolchain_configs/nvcc_msvc.bzl
@@ -599,6 +599,21 @@ def _impl(ctx):
         ],
     )
 
+    # NOTE: this only works on compiler newer than 12.9
+    nvcc_fixed_random_seed_feature = feature(
+        name = "nvcc_fixed_random_seed",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cuda_compile,
+                    ACTION_NAMES.device_link,
+                ],
+                flag_groups = [flag_group(flags = ["--frandom-seed=%{output_file}"])],
+            ),
+        ] if nvcc_version_ge(ctx, 12, 9) else [],
+    )
+
     cuda_device_debug_feature = feature(
         name = "cuda_device_debug",
         flag_sets = [
@@ -646,6 +661,7 @@ def _impl(ctx):
         nvcc_allow_unsupported_compiler_feature,
         nvcc_extended_lambda_feature,
         nvcc_relaxed_constexpr_feature,
+        nvcc_fixed_random_seed_feature,
         cuda_device_debug_feature,
     ]
 


### PR DESCRIPTION
partially fixes #372 for CTK newer than 12.9 (inclusive)