### PR TITLE
Import `stubs/*.so` as interface libraries

### DIFF
--- a/cuda/private/templates/BUILD.cudart
+++ b/cuda/private/templates/BUILD.cudart
@@ -79,7 +79,8 @@ cc_library(
 
 cc_import(
     name = "cuda_so",
-    shared_library = "%{component_name}/%{libpath}/stubs/libcuda.so",
+    interface_library = "%{component_name}/%{libpath}/stubs/libcuda.so",
+    system_provided = 1,
     target_compatible_with = ["@platforms//os:linux"],
 )
 

--- a/cuda/private/templates/BUILD.nvml
+++ b/cuda/private/templates/BUILD.nvml
@@ -1,6 +1,7 @@
 cc_import(
     name = "nvidia-ml_so",
-    shared_library = "%{component_name}/%{libpath}/stubs/libnvidia-ml.so",
+    interface_library = "%{component_name}/%{libpath}/stubs/libnvidia-ml.so",
+    system_provided = 1,
     target_compatible_with = ["@platforms//os:linux"],
 )
 


### PR DESCRIPTION
Stub libraries are not used at runtime (since they don't match their SONAMEs) and not expected to be used at runtime.

Import them explicitly as interface libraries to avoid creating unnecessary entries in runfiles and RUNPATH.