### PR TITLE
If no components specified, use all components.

### DIFF
--- a/cuda/extensions.bzl
+++ b/cuda/extensions.bzl
@@ -37,7 +37,7 @@ cuda_component_tag = tag_class(attrs = {
 
 cuda_redist_json_tag = tag_class(attrs = {
     "name": attr.string(mandatory = True, doc = "Repo name for the cuda_redist_json"),
-    "components": attr.string_list(mandatory = True, doc = "components to be used"),
+    "components": attr.string_list(doc = "Components to be used. If not specified, all components will be used."),
     "integrity": attr.string(
         doc = "Expected checksum in Subresource Integrity format of the file downloaded. " +
               "This must match the checksum of the file downloaded.",

--- a/cuda/private/redist_json_helper.bzl
+++ b/cuda/private/redist_json_helper.bzl
@@ -71,16 +71,18 @@ def _collect_specs(ctx, attr, redist, the_url):
     """
 
     specs = []
-    for c in attr.components:
-        c_full = FULL_COMPONENT_NAME[c]
-        os = None
-        if _is_linux(ctx):
-            os = "linux"
-        elif _is_windows(ctx):
-            os = "windows"
+    os = None
+    if _is_linux(ctx):
+        os = "linux"
+    elif _is_windows(ctx):
+        os = "windows"
 
-        arch = "x86_64"  # TODO: support cross compiling
-        platform = "{os}-{arch}".format(os = os, arch = arch)
+    arch = "x86_64"  # TODO: support cross compiling
+    platform = "{os}-{arch}".format(os = os, arch = arch)
+    components = attr.components if attr.components else [k for k, v in FULL_COMPONENT_NAME.items() if v in redist]
+
+    for c in components:
+        c_full = FULL_COMPONENT_NAME[c]
 
         payload = redist[c_full][platform]
         payload_relative_path = payload["relative_path"]


### PR DESCRIPTION
If the user does not specify the components to be downloaded, it can default to all of them.