### PR TITLE
feat: improve build reproducibility by removing --generate-line-info

### DIFF
--- a/cuda/private/toolchain_configs/nvcc.bzl
+++ b/cuda/private/toolchain_configs/nvcc.bzl
@@ -450,7 +450,7 @@ def _impl(ctx):
         flag_sets = [
             flag_set(
                 actions = [ACTION_NAMES.cuda_compile],
-                flag_groups = [flag_group(flags = ["-O0", "--generate-line-info", "-Xcompiler", "-g1"])],
+                flag_groups = [flag_group(flags = ["-O0", "-Xcompiler", "-g1"])],
             ),
         ],
         provides = ["compilation_mode"],

--- a/tests/flag/BUILD.bazel
+++ b/tests/flag/BUILD.bazel
@@ -64,7 +64,6 @@ cuda_library_c_fastbuild_flag_test(
     contain_flags = [
         # gcc default to -O0 so bazel does not explicitly set the flag. Whereas nvcc defaults to -O3.
         "-O0",
-        "--generate-line-info",
         "-g1",
         # There is no -gmlt option (not merged) as claimed in bazel user manual
         # https://codereview.appspot.com/4440072


### PR DESCRIPTION
Improve build reproducibility / determinism by by removing `--generate-line-info`.

Partially fixes https://github.com/bazel-contrib/rules_cuda/issues/372