### PR TITLE
Include user link flags in device links

### DIFF
--- a/cuda/private/toolchain_configs/nvcc.bzl
+++ b/cuda/private/toolchain_configs/nvcc.bzl
@@ -196,6 +196,11 @@ def _impl(ctx):
                     ],
                 ),
                 flag_group(flags = ["-dlto"], expand_if_true = "use_dlto"),
+                flag_group(
+                    flags = ["%{user_link_flags}"],
+                    iterate_over = "user_link_flags",
+                    expand_if_available = "user_link_flags",
+                ),
             ]),
         ],
         implies = [


### PR DESCRIPTION
I was seeing undefined reference errors when trying to device link a cuda file with NVSHMEM, eg.:
```
nvlink error   : Undefined reference to 'nvshmemi_device_state_d'
```

This PR adds user link flags to the device link command line, so that eg. `-lnvshmem` can be passed down to the device linking, and it fixes the error I encountered above.
