### PR TITLE
Improve clang toolchain discovery, and support hermetic toolchains that don't use built_in_include_directories

### DIFF
--- a/cuda/private/toolchain.bzl
+++ b/cuda/private/toolchain.bzl
@@ -34,6 +34,19 @@ def _get_cc_sysroot(ctx, cc_toolchain):
 
     return None
 
+def _get_cc_compiler(ctx, cc_toolchain):
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
+    return cc_common.get_tool_for_action(
+        feature_configuration = feature_configuration,
+        action_name = CC_ACTION_NAMES.cpp_compile,
+    )
+
 def _cuda_toolchain_impl(ctx):
     cc_toolchain = find_cpp_toolchain(ctx)
     has_compiler_executable = ctx.attr.compiler_executable != None and ctx.attr.compiler_executable != ""
@@ -52,7 +65,7 @@ def _cuda_toolchain_impl(ctx):
 
     # First, attempt to use configured cc_toolchain if attr compiler_use_cc_toolchain set.
     if (ctx.attr.compiler_use_cc_toolchain == True):
-        compiler_executable = cc_toolchain.compiler_executable
+        compiler_executable = _get_cc_compiler(ctx, cc_toolchain)
     elif has_compiler_executable:
         compiler_executable = ctx.attr.compiler_executable
     elif has_compiler_label:

--- a/cuda/private/toolchain_configs/clang.bzl
+++ b/cuda/private/toolchain_configs/clang.bzl
@@ -59,6 +59,7 @@ def _impl(ctx):
         unsupported_features = ctx.disabled_features,
     )
     host_compiler = cc_common.get_tool_for_action(feature_configuration = cc_feature_configuration, action_name = CC_ACTION_NAMES.cpp_compile)
+    env_include = [] if len(cc_toolchain.built_in_include_directories) == 0 else [env_entry("INCLUDE", ";".join(cc_toolchain.built_in_include_directories))]
 
     clang_compile_env_feature = feature(
         name = "clang_compile_env",
@@ -70,9 +71,8 @@ def _impl(ctx):
                     ACTION_NAMES.device_link,
                 ],
                 env_entries = [
-                    env_entry("INCLUDE", ";".join(cc_toolchain.built_in_include_directories)),
                     env_entry("PATH", paths.dirname(host_compiler) + ";C:/Windows/system32"),
-                ],
+                ] + env_include,
             ),
         ],
     )


### PR DESCRIPTION
When using a hermetic cc toolchain with clang, there are no builtin directories to pass and env_entry fails. Additionally, get_tool_for_action is more robust than compiler_executable (e.g. rules-based cc toolchains don't seem to set compiler_executable and we end up with the default gcc)