### PR TITLE
fix: use ctx.getenv instead of ctx.os.environ.get

### DIFF
--- a/cuda/private/redist_json_helper.bzl
+++ b/cuda/private/redist_json_helper.bzl
@@ -10,7 +10,7 @@ def _get_attr_maybe_override(ctx, attr, name):
     # NOTE: these overrides are mainly for CI testing purpose.
     # CUDA_REDIST_INTEGRITY_OVERRIDE, CUDA_REDIST_SHA256_OVERRIDE and CUDA_REDIST_VERSION_OVERRIDE are supported
     value = getattr(attr, name, None)
-    override = ctx.os.environ.get("CUDA_REDIST_" + name.upper() + "_OVERRIDE", None)
+    override = ctx.getenv("CUDA_REDIST_" + name.upper() + "_OVERRIDE")
     if override:
         print("WARNING: Override CUDA redist_json `{}` {} with {} from env.".format(name, value, override))  # buildifier: disable=print
         value = override

--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -29,7 +29,7 @@ def _get_nvcc_version(repository_ctx, nvcc_root):
 def _detect_local_cuda_toolkit(repository_ctx):
     cuda_path = repository_ctx.attr.toolkit_path
     if cuda_path == "":
-        cuda_path = repository_ctx.os.environ.get("CUDA_PATH", None)
+        cuda_path = repository_ctx.getenv("CUDA_PATH")
     if cuda_path == None:
         ptxas_path = repository_ctx.which("ptxas")
         if ptxas_path:
@@ -232,8 +232,8 @@ def detect_clang(repository_ctx):
     """
     bin_ext = ".exe" if _is_windows(repository_ctx) else ""
 
-    clang_path = repository_ctx.os.environ.get("CUDA_CLANG_PATH", None)
-    clang_label = repository_ctx.os.environ.get("CUDA_CLANG_LABEL", None)
+    clang_path = repository_ctx.getenv("CUDA_CLANG_PATH")
+    clang_label = repository_ctx.getenv("CUDA_CLANG_LABEL")
     clang_path_or_label = None
 
     if clang_label != None:
@@ -246,7 +246,7 @@ def detect_clang(repository_ctx):
 
     else:
         # Check BAZEL_LLVM
-        bazel_llvm = repository_ctx.os.environ.get("BAZEL_LLVM", None)
+        bazel_llvm = repository_ctx.getenv("BAZEL_LLVM")
         if bazel_llvm != None and repository_ctx.path(bazel_llvm + "/bin/clang" + bin_ext).exists:
             clang_path_or_label = bazel_llvm + "/bin/clang" + bin_ext
         elif repository_ctx.which("clang") != None:

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -213,7 +213,7 @@ def _generate_toolchain_build(repository_ctx, cuda):
     if cuda.libdevice_label:
         substitutions["# %{libdevice_line}"] = "libdevice = " + repr(cuda.libdevice_label)
 
-    env_tmp = repository_ctx.os.environ.get("TMP", repository_ctx.os.environ.get("TEMP", None))
+    env_tmp = repository_ctx.getenv("TMP", repository_ctx.getenv("TEMP"))
     if env_tmp != None:
         substitutions["%{env_tmp}"] = _to_forward_slash(env_tmp)
     repository_ctx.template("toolchain/BUILD", tpl_label, substitutions = substitutions, executable = False)
@@ -224,7 +224,7 @@ def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
     clang_path_for_subst = ""
     clang_label_for_subst = ""
 
-    compiler_use_cc_toolchain_env = repository_ctx.os.environ.get("CUDA_COMPILER_USE_CC_TOOLCHAIN", "false")
+    compiler_use_cc_toolchain_env = repository_ctx.getenv("CUDA_COMPILER_USE_CC_TOOLCHAIN", "false")
     if compiler_use_cc_toolchain_env == "true":
         compiler_attr_line = "compiler_use_cc_toolchain = True,"
     elif clang_path_or_label != None and (clang_path_or_label.startswith("//") or clang_path_or_label.startswith("@")):


### PR DESCRIPTION
Because retrieving an environment variable from the dictionary does not establish a dependency from a repository rule or module extension to the environment variable.

See https://bazel.build/rules/lib/builtins/repository_os.html#environ