### PR TITLE
Make cc_host_compile_flags configurable

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,7 @@ build --flag_alias=cuda_archs=//cuda:archs
 build --flag_alias=cuda_compiler=//cuda:compiler
 build --flag_alias=cuda_copts=//cuda:copts
 build --flag_alias=cuda_host_copts=//cuda:host_copts
+build --flag_alias=cuda_cc_host_compile_flags_to_skip=//cuda:cc_host_compile_flags_to_skip
 build --flag_alias=cuda_runtime=//cuda:runtime
 
 build --enable_cuda=True

--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ bazel build --cuda_archs=compute_61:compute_61,sm_61
 
   Add copts to the host compiler.
 
+- `@rules_cuda//cuda:cc_host_compile_flags_to_skip`
+
+  Configure which C++ toolchain host compile flags should be filtered out before forwarding to CUDA host compilation.
+  This defaults to skipping `-c`, and can be repeated, for example:
+  `--@rules_cuda//cuda:cc_host_compile_flags_to_skip=-c --@rules_cuda//cuda:cc_host_compile_flags_to_skip=-fno-canonical-system-headers`.
+
 - `@rules_cuda//cuda:runtime`
 
   Set the default cudart to link; for example, `--@rules_cuda//cuda:runtime=@cuda//:cuda_runtime_static` links the static CUDA runtime.

--- a/cuda/BUILD.bazel
+++ b/cuda/BUILD.bazel
@@ -118,6 +118,11 @@ repeatable_string_flag(
     build_setting_default = "",
 )
 
+repeatable_string_flag(
+    name = "cc_host_compile_flags_to_skip",
+    build_setting_default = "-c",
+)
+
 # Command line flag to specify the CUDA runtime. Use this target as CUDA
 # runtime dependency.
 #

--- a/cuda/private/cuda_helper.bzl
+++ b/cuda/private/cuda_helper.bzl
@@ -292,14 +292,9 @@ def _get_cc_host_compile_flags(ctx):
         variables = variables,
     )
 
-    flags_to_skip = [
-        "-c",
-    ]
-
-    if cuda_toolchain.toolchain_identifier == "clang":
-        flags_to_skip.append(
-            "-fno-canonical-system-headers",
-        )
+    base = ctx.attr._cc_host_compile_flags_to_skip[BuildSettingInfo].value
+    extra = ["-fno-canonical-system-headers"] if cuda_toolchain.toolchain_identifier == "clang" else []
+    flags_to_skip = list(base) + extra
 
     flag_prefixes_to_skip = [
         "-std=",

--- a/cuda/private/rules/cuda_library.bzl
+++ b/cuda/private/rules/cuda_library.bzl
@@ -175,6 +175,7 @@ cuda_library = rule(
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),  # legacy behaviour
         "_default_cuda_copts": attr.label(default = "//cuda:copts"),
         "_default_host_copts": attr.label(default = "//cuda:host_copts"),
+        "_cc_host_compile_flags_to_skip": attr.label(default = "//cuda:cc_host_compile_flags_to_skip"),
         "_default_cuda_archs": attr.label(default = "//cuda:archs"),
     },
     fragments = ["cpp"],

--- a/cuda/private/rules/cuda_objects.bzl
+++ b/cuda/private/rules/cuda_objects.bzl
@@ -110,6 +110,7 @@ code and device link time optimization source files.""",
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),  # legacy behaviour
         "_default_cuda_copts": attr.label(default = "//cuda:copts"),
         "_default_host_copts": attr.label(default = "//cuda:host_copts"),
+        "_cc_host_compile_flags_to_skip": attr.label(default = "//cuda:cc_host_compile_flags_to_skip"),
         "_default_cuda_archs": attr.label(default = "//cuda:archs"),
     },
     fragments = ["cpp"],

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -5,6 +5,7 @@ build --flag_alias=enable_cuda=@rules_cuda//cuda:enable
 build --flag_alias=cuda_archs=@rules_cuda//cuda:archs
 build --flag_alias=cuda_compiler=@rules_cuda//cuda:compiler
 build --flag_alias=cuda_copts=@rules_cuda//cuda:copts
+build --flag_alias=cuda_cc_host_compile_flags_to_skip=@rules_cuda//cuda:cc_host_compile_flags_to_skip
 build --flag_alias=cuda_runtime=@rules_cuda//cuda:runtime
 
 build --enable_cuda=True


### PR DESCRIPTION
Extending https://github.com/bazel-contrib/rules_cuda/pull/419. Depending on which compiler you are using, some flags should be skipped. This PR makes the `flags_to_skip` hardcoded in https://github.com/bazel-contrib/rules_cuda/pull/419 configurable via the command line.