### PR TITLE
Auto-detect CUDA platform from @platforms constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ use_repo(cuda, "cuda")
 #### Multi-version hermetic toolchains (Bzlmod)
 
 To select CUDA versions and platforms at build time, define multiple `cuda.redist_json` entries and a single `cuda.toolkit`.
-Then use `@rules_cuda//cuda:version`, `@rules_cuda//cuda:exec_platform`, and `@rules_cuda//cuda:target_platform` flags.
-If `@rules_cuda//cuda:version` is unset, rules_cuda selects the highest declared redist version.
+The target CUDA redist is auto-detected from the active target platform's `@platforms//cpu` + `@platforms//os` + `@rules_cuda//cuda:gpu_kind` constraints —
+set `--platforms` to control it (predefined platforms `@rules_cuda//cuda:linux_x86_64`, `:linux_sbsa`, `:linux_aarch64`, `:windows_x86_64` are provided).
+Use `@rules_cuda//cuda:version` to pick the CUDA version (defaults to the highest declared if unset),
+and `@rules_cuda//cuda:exec_platform` as an escape hatch to override the auto-detected exec redist.
 
 ```starlark
 cuda = use_extension("@rules_cuda//cuda:extensions.bzl", "toolchain")
@@ -65,8 +67,7 @@ use_repo(cuda, "cuda")
 Example `.bazelrc` entries:
 
 ```
-build --@rules_cuda//cuda:exec_platform=linux-x86_64
-build --@rules_cuda//cuda:target_platform=linux-x86_64
+build --platforms=@rules_cuda//cuda:linux_x86_64
 # Optional: if omitted, the highest declared redist version is used.
 build --@rules_cuda//cuda:version=13.0.0
 ```

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ use_repo(cuda, "cuda")
 #### Multi-version hermetic toolchains (Bzlmod)
 
 To select CUDA versions and platforms at build time, define multiple `cuda.redist_json` entries and a single `cuda.toolkit`.
-The target CUDA redist is auto-detected from the active target platform's `@platforms//cpu` + `@platforms//os` + `@rules_cuda//cuda:gpu_kind` constraints —
-set `--platforms` to control it (predefined platforms `@rules_cuda//cuda:linux_x86_64`, `:linux_sbsa`, `:linux_aarch64`, `:windows_x86_64` are provided).
+The target CUDA redist is auto-detected from the active target platform's `@platforms//cpu` + `@platforms//os` constraints.
+Set `--platforms` to control it. linux-sbsa and linux-aarch64 share aarch64+linux constraints; the `@rules_cuda//cuda:target_gpu` flag
+disambiguates them (default `discrete` → linux-sbsa, set to `on_die` for Tegra/Jetson/Drive Thor → linux-aarch64).
 Use `@rules_cuda//cuda:version` to pick the CUDA version (defaults to the highest declared if unset),
 and `@rules_cuda//cuda:exec_platform` as an escape hatch to override the auto-detected exec redist.
 
@@ -67,7 +68,9 @@ use_repo(cuda, "cuda")
 Example `.bazelrc` entries:
 
 ```
-build --platforms=@rules_cuda//cuda:linux_x86_64
+build --platforms=//:my_x86_platform
+# For Tegra/Drive Thor targets (linux-aarch64 redist):
+# build --platforms=//:my_aarch64_platform --@rules_cuda//cuda:target_gpu=on_die
 # Optional: if omitted, the highest declared redist version is used.
 build --@rules_cuda//cuda:version=13.0.0
 ```

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ use_repo(cuda, "cuda")
 
 To select CUDA versions and platforms at build time, define multiple `cuda.redist_json` entries and a single `cuda.toolkit`.
 The target CUDA redist is auto-detected from the active target platform's `@platforms//cpu` + `@platforms//os` constraints.
-Set `--platforms` to control it. linux-sbsa and linux-aarch64 share aarch64+linux constraints; the `@rules_cuda//cuda:target_gpu` flag
-disambiguates them (default `discrete` → linux-sbsa, set to `on_die` for Tegra/Jetson/Drive Thor → linux-aarch64).
+Set `--platforms` to control it. linux-sbsa and linux-aarch64 share aarch64+linux constraints; the `@rules_cuda//cuda:aarch64` flag
+disambiguates them (default `sbsa` → linux-sbsa, set to `aarch64` for Tegra/Jetson/Drive Thor → linux-aarch64).
 Use `@rules_cuda//cuda:version` to pick the CUDA version (defaults to the highest declared if unset),
 and `@rules_cuda//cuda:exec_platform` as an escape hatch to override the auto-detected exec redist.
 
@@ -70,7 +70,7 @@ Example `.bazelrc` entries:
 ```
 build --platforms=//:my_x86_platform
 # For Tegra/Drive Thor targets (linux-aarch64 redist):
-# build --platforms=//:my_aarch64_platform --@rules_cuda//cuda:target_gpu=on_die
+# build --platforms=//:my_aarch64_platform --@rules_cuda//cuda:aarch64=aarch64
 # Optional: if omitted, the highest declared redist version is used.
 build --@rules_cuda//cuda:version=13.0.0
 ```

--- a/cuda/BUILD.bazel
+++ b/cuda/BUILD.bazel
@@ -46,25 +46,26 @@ string_flag(
 )
 
 # NOTE: Functional with platform_alias only.
-string_flag(
-    name = "target_platform",
-    build_setting_default = "linux-x86_64",
-    values = SUPPORTED_PLATFORMS,
-)
-
-[
-    config_setting(
-        name = "target_platform_is_{}".format(platform.replace("-", "_")),
-        flag_values = {":target_platform": platform},
-    )
-    for platform in SUPPORTED_PLATFORMS
-]
-
-# NOTE: Functional with platform_alias only.
+#
+# Default is "" which means "auto-detect from the active exec platform's
+# @platforms//cpu + @platforms//os + :gpu_kind constraints". Explicitly
+# setting to one of SUPPORTED_PLATFORMS pins the exec redist regardless of
+# host.
+#
+# Override is needed when the active exec configuration's platform doesn't
+# carry the constraints that auto-detection keys on. Common examples:
+#   - An RBE exec pool whose registered platform is missing :gpu_kind, so an
+#     aarch64 pool with on-die GPU resolves to linux-sbsa instead of
+#     linux-aarch64.
+#   - Running nvcc under emulation where the binary you actually want to
+#     invoke doesn't match the platform Bazel sees.
+# Prefer fixing the platform definition (add the constraint, or use a thin
+# wrapper platform with parents=...) over setting this flag — this is an
+# escape hatch.
 string_flag(
     name = "exec_platform",
-    build_setting_default = "linux-x86_64",
-    values = SUPPORTED_PLATFORMS,
+    build_setting_default = "",
+    values = [""] + SUPPORTED_PLATFORMS,
 )
 
 [
@@ -74,6 +75,120 @@ string_flag(
     )
     for platform in SUPPORTED_PLATFORMS
 ]
+
+# === GPU kind constraint ===
+#
+# Disambiguates linux-sbsa (server-class ARM, discrete GPU on PCIe — Grace,
+# A4X, Graviton+GPU) from linux-aarch64 (NVIDIA's Tegra/Jetson/Drive embedded
+# redist with on-die GPU). Both have @platforms//cpu:aarch64 + os:linux, so a
+# custom constraint is needed to tell them apart.
+#
+# Default is :discrete_gpu, so platforms that don't explicitly set this
+# (e.g. a vanilla aarch64-Linux platform defined by a downstream consumer)
+# auto-resolve to linux-sbsa — the safer choice since the sbsa redist's
+# libraries don't depend on Tegra-specific kernel modules.
+#
+# Consumers targeting Tegra hardware should either:
+#   - use --platforms=@rules_cuda//cuda:linux_aarch64 (predefined), or
+#   - add "@rules_cuda//cuda:on_die_gpu" to their own platform's
+#     constraint_values.
+constraint_setting(
+    name = "gpu_kind",
+    default_constraint_value = ":discrete_gpu",
+)
+
+constraint_value(
+    name = "discrete_gpu",
+    constraint_setting = ":gpu_kind",
+)
+
+constraint_value(
+    name = "on_die_gpu",
+    constraint_setting = ":gpu_kind",
+)
+
+# Predefined platforms mirroring NVIDIA's CUDA redist platform names. Use
+# these as --platforms=@rules_cuda//cuda:<name> for fully unambiguous
+# CUDA-aware platform selection. Downstream platforms that already exist
+# (e.g. //:linux_amd64) continue to work; aarch64 platforms without an
+# explicit gpu_kind default to :discrete_gpu and resolve to linux-sbsa.
+platform(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
+    name = "linux_sbsa",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+        ":discrete_gpu",
+    ],
+)
+
+platform(
+    name = "linux_aarch64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+        ":on_die_gpu",
+    ],
+)
+
+platform(
+    name = "windows_x86_64",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+# Platform-detection config_settings keyed on standard @platforms constraints
+# plus the rules_cuda :gpu_kind constraint where needed for disambiguation.
+# A config_setting with constraint_values evaluates against the *active
+# configuration's* platform: at exec config that's the exec platform, at
+# target config that's the target platform. Same setting, two uses depending
+# on where it's referenced from.
+#
+# RBE-safe: the constraint check fires against the configuration's platform,
+# not the user's host. An x86 host driving aarch64 remote workers gets the
+# aarch64 match at exec config.
+config_setting(
+    name = "is_linux_x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "is_linux_sbsa",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+        ":discrete_gpu",
+    ],
+)
+
+config_setting(
+    name = "is_linux_aarch64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+        ":on_die_gpu",
+    ],
+)
+
+config_setting(
+    name = "is_windows_x86_64",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+)
 
 # Command line flag to specify the list of CUDA architectures to compile for.
 #

--- a/cuda/BUILD.bazel
+++ b/cuda/BUILD.bazel
@@ -48,20 +48,20 @@ string_flag(
 # NOTE: Functional with platform_alias only.
 #
 # Default is "" which means "auto-detect from the active exec platform's
-# @platforms//cpu + @platforms//os + :gpu_kind constraints". Explicitly
-# setting to one of SUPPORTED_PLATFORMS pins the exec redist regardless of
-# host.
+# @platforms//cpu + @platforms//os constraints (with :target_gpu narrowing
+# the aarch64-linux case)". Explicitly setting to one of SUPPORTED_PLATFORMS
+# pins the exec redist regardless of host.
 #
 # Override is needed when the active exec configuration's platform doesn't
-# carry the constraints that auto-detection keys on. Common examples:
-#   - An RBE exec pool whose registered platform is missing :gpu_kind, so an
-#     aarch64 pool with on-die GPU resolves to linux-sbsa instead of
-#     linux-aarch64.
+# carry the constraints that auto-detection keys on, or when the single
+# global :target_gpu flag picks the wrong variant for the exec side. Common
+# examples:
+#   - Cross-compile from a Grace/A4X (sbsa) host to a Drive Thor target:
+#     :target_gpu must be on_die for the target, but the exec auto-detects
+#     to linux-aarch64 nvcc instead of linux-sbsa nvcc. Set this flag to
+#     linux-sbsa to override.
 #   - Running nvcc under emulation where the binary you actually want to
 #     invoke doesn't match the platform Bazel sees.
-# Prefer fixing the platform definition (add the constraint, or use a thin
-# wrapper platform with parents=...) over setting this flag — this is an
-# escape hatch.
 string_flag(
     name = "exec_platform",
     build_setting_default = "",
@@ -76,78 +76,36 @@ string_flag(
     for platform in SUPPORTED_PLATFORMS
 ]
 
-# === GPU kind constraint ===
+# === Aarch64 redist disambiguation ===
 #
-# Disambiguates linux-sbsa (server-class ARM, discrete GPU on PCIe — Grace,
-# A4X, Graviton+GPU) from linux-aarch64 (NVIDIA's Tegra/Jetson/Drive embedded
-# redist with on-die GPU). Both have @platforms//cpu:aarch64 + os:linux, so a
-# custom constraint is needed to tell them apart.
+# linux-sbsa (server-class ARM, discrete GPU on PCIe — Grace, A4X,
+# Graviton+GPU) and linux-aarch64 (NVIDIA's Tegra/Jetson/Drive embedded
+# redist with on-die GPU) share @platforms//cpu:aarch64 + os:linux. Standard
+# Bazel constraints can't tell them apart, so this CUDA-internal flag
+# selects which redist to use when the active configuration's platform is
+# aarch64-linux. The flag is a no-op on x86 and Windows platforms — the
+# outer alias matches those via @platforms constraints alone.
 #
-# Default is :discrete_gpu, so platforms that don't explicitly set this
-# (e.g. a vanilla aarch64-Linux platform defined by a downstream consumer)
-# auto-resolve to linux-sbsa — the safer choice since the sbsa redist's
-# libraries don't depend on Tegra-specific kernel modules.
-#
-# Consumers targeting Tegra hardware should either:
-#   - use --platforms=@rules_cuda//cuda:linux_aarch64 (predefined), or
-#   - add "@rules_cuda//cuda:on_die_gpu" to their own platform's
-#     constraint_values.
-constraint_setting(
-    name = "gpu_kind",
-    default_constraint_value = ":discrete_gpu",
+# Default is :discrete (linux-sbsa) — the safer fallback since the sbsa
+# redist's libraries don't depend on Tegra-specific kernel modules. Tegra
+# / Drive Thor users should set --@rules_cuda//cuda:target_gpu=on_die.
+string_flag(
+    name = "target_gpu",
+    build_setting_default = "discrete",
+    values = ["discrete", "on_die"],
 )
 
-constraint_value(
-    name = "discrete_gpu",
-    constraint_setting = ":gpu_kind",
+config_setting(
+    name = "target_gpu_is_discrete",
+    flag_values = {":target_gpu": "discrete"},
 )
 
-constraint_value(
-    name = "on_die_gpu",
-    constraint_setting = ":gpu_kind",
+config_setting(
+    name = "target_gpu_is_on_die",
+    flag_values = {":target_gpu": "on_die"},
 )
 
-# Predefined platforms mirroring NVIDIA's CUDA redist platform names. Use
-# these as --platforms=@rules_cuda//cuda:<name> for fully unambiguous
-# CUDA-aware platform selection. Downstream platforms that already exist
-# (e.g. //:linux_amd64) continue to work; aarch64 platforms without an
-# explicit gpu_kind default to :discrete_gpu and resolve to linux-sbsa.
-platform(
-    name = "linux_x86_64",
-    constraint_values = [
-        "@platforms//os:linux",
-        "@platforms//cpu:x86_64",
-    ],
-)
-
-platform(
-    name = "linux_sbsa",
-    constraint_values = [
-        "@platforms//os:linux",
-        "@platforms//cpu:aarch64",
-        ":discrete_gpu",
-    ],
-)
-
-platform(
-    name = "linux_aarch64",
-    constraint_values = [
-        "@platforms//os:linux",
-        "@platforms//cpu:aarch64",
-        ":on_die_gpu",
-    ],
-)
-
-platform(
-    name = "windows_x86_64",
-    constraint_values = [
-        "@platforms//os:windows",
-        "@platforms//cpu:x86_64",
-    ],
-)
-
-# Platform-detection config_settings keyed on standard @platforms constraints
-# plus the rules_cuda :gpu_kind constraint where needed for disambiguation.
+# Platform-detection config_settings keyed on standard @platforms constraints.
 # A config_setting with constraint_values evaluates against the *active
 # configuration's* platform: at exec config that's the exec platform, at
 # target config that's the target platform. Same setting, two uses depending
@@ -156,6 +114,9 @@ platform(
 # RBE-safe: the constraint check fires against the configuration's platform,
 # not the user's host. An x86 host driving aarch64 remote workers gets the
 # aarch64 match at exec config.
+#
+# linux-sbsa and linux-aarch64 share these constraints; the inner alias
+# (generated per component) routes between them via :target_gpu.
 config_setting(
     name = "is_linux_x86_64",
     constraint_values = [
@@ -165,20 +126,10 @@ config_setting(
 )
 
 config_setting(
-    name = "is_linux_sbsa",
+    name = "is_linux_aarch64_or_sbsa",
     constraint_values = [
         "@platforms//os:linux",
         "@platforms//cpu:aarch64",
-        ":discrete_gpu",
-    ],
-)
-
-config_setting(
-    name = "is_linux_aarch64",
-    constraint_values = [
-        "@platforms//os:linux",
-        "@platforms//cpu:aarch64",
-        ":on_die_gpu",
     ],
 )
 

--- a/cuda/BUILD.bazel
+++ b/cuda/BUILD.bazel
@@ -92,7 +92,10 @@ string_flag(
 string_flag(
     name = "target_gpu",
     build_setting_default = "discrete",
-    values = ["discrete", "on_die"],
+    values = [
+        "discrete",
+        "on_die",
+    ],
 )
 
 config_setting(

--- a/cuda/BUILD.bazel
+++ b/cuda/BUILD.bazel
@@ -48,16 +48,16 @@ string_flag(
 # NOTE: Functional with platform_alias only.
 #
 # Default is "" which means "auto-detect from the active exec platform's
-# @platforms//cpu + @platforms//os constraints (with :target_gpu narrowing
+# @platforms//cpu + @platforms//os constraints (with :aarch64 narrowing
 # the aarch64-linux case)". Explicitly setting to one of SUPPORTED_PLATFORMS
 # pins the exec redist regardless of host.
 #
 # Override is needed when the active exec configuration's platform doesn't
 # carry the constraints that auto-detection keys on, or when the single
-# global :target_gpu flag picks the wrong variant for the exec side. Common
+# global :aarch64 flag picks the wrong variant for the exec side. Common
 # examples:
 #   - Cross-compile from a Grace/A4X (sbsa) host to a Drive Thor target:
-#     :target_gpu must be on_die for the target, but the exec auto-detects
+#     :aarch64 must be aarch64 for the target, but the exec auto-detects
 #     to linux-aarch64 nvcc instead of linux-sbsa nvcc. Set this flag to
 #     linux-sbsa to override.
 #   - Running nvcc under emulation where the binary you actually want to
@@ -86,26 +86,26 @@ string_flag(
 # aarch64-linux. The flag is a no-op on x86 and Windows platforms — the
 # outer alias matches those via @platforms constraints alone.
 #
-# Default is :discrete (linux-sbsa) — the safer fallback since the sbsa
+# Default is sbsa (server-class) — the safer fallback since the sbsa
 # redist's libraries don't depend on Tegra-specific kernel modules. Tegra
-# / Drive Thor users should set --@rules_cuda//cuda:target_gpu=on_die.
+# / Drive Thor users should set --@rules_cuda//cuda:aarch64=aarch64.
 string_flag(
-    name = "target_gpu",
-    build_setting_default = "discrete",
+    name = "aarch64",
+    build_setting_default = "sbsa",
     values = [
-        "discrete",
-        "on_die",
+        "sbsa",
+        "aarch64",
     ],
 )
 
 config_setting(
-    name = "target_gpu_is_discrete",
-    flag_values = {":target_gpu": "discrete"},
+    name = "aarch64_is_sbsa",
+    flag_values = {":aarch64": "sbsa"},
 )
 
 config_setting(
-    name = "target_gpu_is_on_die",
-    flag_values = {":target_gpu": "on_die"},
+    name = "aarch64_is_aarch64",
+    flag_values = {":aarch64": "aarch64"},
 )
 
 # Platform-detection config_settings keyed on standard @platforms constraints.
@@ -119,7 +119,7 @@ config_setting(
 # aarch64 match at exec config.
 #
 # linux-sbsa and linux-aarch64 share these constraints; the inner alias
-# (generated per component) routes between them via :target_gpu.
+# (generated per component) routes between them via :aarch64.
 config_setting(
     name = "is_linux_x86_64",
     constraint_values = [

--- a/cuda/platform_alias_extension.bzl
+++ b/cuda/platform_alias_extension.bzl
@@ -169,6 +169,7 @@ def _platform_alias_repo_impl(ctx):
             build_content.append('    visibility = ["//visibility:public"],')
             build_content.append(")")
             build_content.append("")
+
             # Auto-detection fallback. Private — only the outer flag-select
             # in this same package needs to reach it.
             _emit_constraint_select_alias(

--- a/cuda/platform_alias_extension.bzl
+++ b/cuda/platform_alias_extension.bzl
@@ -11,26 +11,37 @@ load("//cuda/private:templates/registry.bzl", "REGISTRY")
 TARGET_MAPPING = REGISTRY
 
 # Mapping from @platforms-constraint config_settings (in @rules_cuda//cuda)
-# to the canonical CUDA platform they should resolve to. Used to build the
-# auto-detection alias for both target and exec components.
+# to the canonical CUDA platform they should resolve to. Covers only the
+# platforms unambiguously identified by @platforms//cpu + @platforms//os
+# alone. linux-sbsa and linux-aarch64 share aarch64+linux constraints and
+# are routed via :is_linux_aarch64_or_sbsa to a nested alias keyed on the
+# :target_gpu flag.
 #
 # The constraint check evaluates against the *active configuration's* platform
 # (exec at cfg="exec", target otherwise) — RBE-safe and reuses Bazel's normal
-# platform resolution. linux-sbsa and linux-aarch64 are disambiguated by the
-# :gpu_kind constraint (default :discrete_gpu, override with :on_die_gpu).
+# platform resolution.
 #
 # Adding a new platform to SUPPORTED_PLATFORMS requires three matching changes:
 #   1. A new `is_<platform>` config_setting in //cuda:BUILD.bazel
-#   2. A new constraint_value if the new platform needs disambiguation from an
-#      existing one (see :gpu_kind / :on_die_gpu for the aarch64 case)
-#   3. A new entry in this list mapping the config_setting to the platform name
+#   2. If the new platform shares cpu+os with another, a disambiguation
+#      mechanism (see :target_gpu and :is_linux_aarch64_or_sbsa for the
+#      aarch64 case)
+#   3. A new entry in this list (or in _AARCH64_FROM_TARGET_GPU below for
+#      aarch64-only additions)
 # Without all three, the new platform will silently fall through to
 # :unsupported_cuda_platform with no diagnostic.
 _AUTO_FROM_CONSTRAINT = [
     ("is_linux_x86_64", "linux-x86_64"),
-    ("is_linux_sbsa", "linux-sbsa"),
-    ("is_linux_aarch64", "linux-aarch64"),
     ("is_windows_x86_64", "windows-x86_64"),
+]
+
+# Mapping from :target_gpu-flag config_settings to the aarch64-linux CUDA
+# platform they resolve to. Drives the inner alias that disambiguates
+# linux-sbsa (server-class ARM, discrete GPU) from linux-aarch64 (Tegra/Drive
+# embedded, on-die GPU).
+_AARCH64_FROM_TARGET_GPU = [
+    ("target_gpu_is_discrete", "linux-sbsa"),
+    ("target_gpu_is_on_die", "linux-aarch64"),
 ]
 
 def _platform_repos_attr(platform):
@@ -51,12 +62,36 @@ def _version_sort_key(version):
         return (1, [int(p) for p in parts], version)
     return (0, [], version)
 
-def _emit_constraint_select_alias(build_content, alias_name, target_name, platforms_available, dummy_target, visibility):
-    """Emit an alias whose actual is the constraint-based platform select.
+def _emit_aarch64_inner_alias(build_content, alias_name, target_name, platforms_available, dummy_target):
+    """Emit the private inner alias that disambiguates linux-sbsa vs linux-aarch64.
+
+    Keyed on the :target_gpu flag (discrete -> linux-sbsa, on_die ->
+    linux-aarch64). Referenced from the outer constraint-based alias when
+    the active config's platform is aarch64-linux.
+    """
+    build_content.append("alias(")
+    build_content.append('    name = "{}",'.format(alias_name))
+    build_content.append("    actual = select({")
+    for setting, platform in _AARCH64_FROM_TARGET_GPU:
+        platform_suffix = platform.replace("-", "_")
+        build_content.append('        "@rules_cuda//cuda:{}":'.format(setting))
+        if platform in platforms_available:
+            build_content.append('            ":{}_{}",'.format(platform_suffix, target_name))
+        else:
+            build_content.append('            "{}",'.format(dummy_target))
+    build_content.append("    }),")
+    build_content.append('    visibility = ["//visibility:private"],')
+    build_content.append(")")
+    build_content.append("")
+
+def _emit_outer_constraint_alias(build_content, alias_name, target_name, platforms_available, dummy_target, visibility, aarch64_inner_name):
+    """Emit the alias whose actual is the @platforms-constraint platform select.
 
     Used directly for target components and as the auto-detection fallback
-    for exec components. Constraint check fires against the active config's
-    platform (exec at cfg="exec", target otherwise) — RBE-safe.
+    for exec components. For aarch64-linux configs, routes to the private
+    :target_gpu-keyed inner alias passed as aarch64_inner_name. Constraint
+    check fires against the active config's platform (exec at cfg="exec",
+    target otherwise) — RBE-safe.
     """
     build_content.append("alias(")
     build_content.append('    name = "{}",'.format(alias_name))
@@ -68,6 +103,8 @@ def _emit_constraint_select_alias(build_content, alias_name, target_name, platfo
             build_content.append('            ":{}_{}",'.format(platform_suffix, target_name))
         else:
             build_content.append('            "{}",'.format(dummy_target))
+    build_content.append('        "@rules_cuda//cuda:is_linux_aarch64_or_sbsa":')
+    build_content.append('            ":{}",'.format(aarch64_inner_name))
     build_content.append('        "//conditions:default": ":unsupported_cuda_platform",')
     build_content.append("    }),")
     build_content.append('    visibility = ["{}"],'.format(visibility))
@@ -148,6 +185,17 @@ def _platform_alias_repo_impl(ctx):
         elif target_name == "libdevice.10.bc":
             dummy_target = "@rules_cuda//cuda/dummy:libdevice.10.bc"
 
+        # Inner aarch64 disambiguation alias, shared by the target / exec
+        # outer aliases when the active config's platform is aarch64-linux.
+        aarch64_inner_name = "aarch64_or_sbsa_" + target_name
+        _emit_aarch64_inner_alias(
+            build_content,
+            aarch64_inner_name,
+            target_name,
+            platforms_available,
+            dummy_target,
+        )
+
         if platform_type == "exec":
             # Outer alias: explicit --exec_platform flag wins; the default
             # branch falls through to constraint-based auto-detection in
@@ -172,24 +220,27 @@ def _platform_alias_repo_impl(ctx):
 
             # Auto-detection fallback. Private — only the outer flag-select
             # in this same package needs to reach it.
-            _emit_constraint_select_alias(
+            _emit_outer_constraint_alias(
                 build_content,
                 "auto_" + target_name,
                 target_name,
                 platforms_available,
                 dummy_target,
                 "//visibility:private",
+                aarch64_inner_name,
             )
         else:
-            # Target components: single alias with constraint-based select
-            # inlined. --platforms is the only knob (no flag override layer).
-            _emit_constraint_select_alias(
+            # Target components: single outer alias keyed on @platforms
+            # constraints. --platforms is the primary knob; :target_gpu
+            # picks the aarch64 variant in the inner alias.
+            _emit_outer_constraint_alias(
                 build_content,
                 target_name,
                 target_name,
                 platforms_available,
                 dummy_target,
                 "//visibility:public",
+                aarch64_inner_name,
             )
 
         # Generate platform-specific aliases for ALL platforms.

--- a/cuda/platform_alias_extension.bzl
+++ b/cuda/platform_alias_extension.bzl
@@ -10,6 +10,29 @@ load("//cuda/private:templates/registry.bzl", "REGISTRY")
 # Use REGISTRY as the source of truth for component targets
 TARGET_MAPPING = REGISTRY
 
+# Mapping from @platforms-constraint config_settings (in @rules_cuda//cuda)
+# to the canonical CUDA platform they should resolve to. Used to build the
+# auto-detection alias for both target and exec components.
+#
+# The constraint check evaluates against the *active configuration's* platform
+# (exec at cfg="exec", target otherwise) — RBE-safe and reuses Bazel's normal
+# platform resolution. linux-sbsa and linux-aarch64 are disambiguated by the
+# :gpu_kind constraint (default :discrete_gpu, override with :on_die_gpu).
+#
+# Adding a new platform to SUPPORTED_PLATFORMS requires three matching changes:
+#   1. A new `is_<platform>` config_setting in //cuda:BUILD.bazel
+#   2. A new constraint_value if the new platform needs disambiguation from an
+#      existing one (see :gpu_kind / :on_die_gpu for the aarch64 case)
+#   3. A new entry in this list mapping the config_setting to the platform name
+# Without all three, the new platform will silently fall through to
+# :unsupported_cuda_platform with no diagnostic.
+_AUTO_FROM_CONSTRAINT = [
+    ("is_linux_x86_64", "linux-x86_64"),
+    ("is_linux_sbsa", "linux-sbsa"),
+    ("is_linux_aarch64", "linux-aarch64"),
+    ("is_windows_x86_64", "windows-x86_64"),
+]
+
 def _platform_repos_attr(platform):
     return platform.replace("-", "_") + "_repos"
 
@@ -27,6 +50,29 @@ def _version_sort_key(version):
     if all([p.isdigit() for p in parts]):
         return (1, [int(p) for p in parts], version)
     return (0, [], version)
+
+def _emit_constraint_select_alias(build_content, alias_name, target_name, platforms_available, dummy_target, visibility):
+    """Emit an alias whose actual is the constraint-based platform select.
+
+    Used directly for target components and as the auto-detection fallback
+    for exec components. Constraint check fires against the active config's
+    platform (exec at cfg="exec", target otherwise) — RBE-safe.
+    """
+    build_content.append("alias(")
+    build_content.append('    name = "{}",'.format(alias_name))
+    build_content.append("    actual = select({")
+    for setting, platform in _AUTO_FROM_CONSTRAINT:
+        platform_suffix = platform.replace("-", "_")
+        build_content.append('        "@rules_cuda//cuda:{}":'.format(setting))
+        if platform in platforms_available:
+            build_content.append('            ":{}_{}",'.format(platform_suffix, target_name))
+        else:
+            build_content.append('            "{}",'.format(dummy_target))
+    build_content.append('        "//conditions:default": ":unsupported_cuda_platform",')
+    build_content.append("    }),")
+    build_content.append('    visibility = ["{}"],'.format(visibility))
+    build_content.append(")")
+    build_content.append("")
 
 def _platform_alias_repo_impl(ctx):
     """Implementation of the platform_alias_repo repository rule.
@@ -102,26 +148,48 @@ def _platform_alias_repo_impl(ctx):
         elif target_name == "libdevice.10.bc":
             dummy_target = "@rules_cuda//cuda/dummy:libdevice.10.bc"
 
-        build_content.append("alias(")
-        build_content.append('    name = "{}",'.format(target_name))
-        build_content.append("    actual = select({")
-
-        # Add conditions for ALL platforms, using dummy for unavailable ones.
-        for platform in SUPPORTED_PLATFORMS:
-            platform_suffix = platform.replace("-", "_")
-            build_content.append(
-                '        "@rules_cuda//cuda:{}_platform_is_{}":'.format(platform_type, platform_suffix),
+        if platform_type == "exec":
+            # Outer alias: explicit --exec_platform flag wins; the default
+            # branch falls through to constraint-based auto-detection in
+            # the private :auto_<name> alias below.
+            build_content.append("alias(")
+            build_content.append('    name = "{}",'.format(target_name))
+            build_content.append("    actual = select({")
+            for platform in SUPPORTED_PLATFORMS:
+                platform_suffix = platform.replace("-", "_")
+                build_content.append(
+                    '        "@rules_cuda//cuda:exec_platform_is_{}":'.format(platform_suffix),
+                )
+                if platform in platforms_available:
+                    build_content.append('            ":{}_{}",'.format(platform_suffix, target_name))
+                else:
+                    build_content.append('            "{}",'.format(dummy_target))
+            build_content.append('        "//conditions:default": ":auto_{}",'.format(target_name))
+            build_content.append("    }),")
+            build_content.append('    visibility = ["//visibility:public"],')
+            build_content.append(")")
+            build_content.append("")
+            # Auto-detection fallback. Private — only the outer flag-select
+            # in this same package needs to reach it.
+            _emit_constraint_select_alias(
+                build_content,
+                "auto_" + target_name,
+                target_name,
+                platforms_available,
+                dummy_target,
+                "//visibility:private",
             )
-            if platform in platforms_available:
-                build_content.append('            ":{}_{}",'.format(platform_suffix, target_name))
-            else:
-                # Platform doesn't have this component, use dummy target.
-                build_content.append('            "{}",'.format(dummy_target))
-        build_content.append('        "//conditions:default": ":unsupported_cuda_platform",')
-        build_content.append("    }),")
-        build_content.append('    visibility = ["//visibility:public"],')
-        build_content.append(")")
-        build_content.append("")
+        else:
+            # Target components: single alias with constraint-based select
+            # inlined. --platforms is the only knob (no flag override layer).
+            _emit_constraint_select_alias(
+                build_content,
+                target_name,
+                target_name,
+                platforms_available,
+                dummy_target,
+                "//visibility:public",
+            )
 
         # Generate platform-specific aliases for ALL platforms.
         # Platforms where the component exists get version-based selection.

--- a/cuda/platform_alias_extension.bzl
+++ b/cuda/platform_alias_extension.bzl
@@ -15,7 +15,7 @@ TARGET_MAPPING = REGISTRY
 # platforms unambiguously identified by @platforms//cpu + @platforms//os
 # alone. linux-sbsa and linux-aarch64 share aarch64+linux constraints and
 # are routed via :is_linux_aarch64_or_sbsa to a nested alias keyed on the
-# :target_gpu flag.
+# :aarch64 flag.
 #
 # The constraint check evaluates against the *active configuration's* platform
 # (exec at cfg="exec", target otherwise) — RBE-safe and reuses Bazel's normal
@@ -24,9 +24,9 @@ TARGET_MAPPING = REGISTRY
 # Adding a new platform to SUPPORTED_PLATFORMS requires three matching changes:
 #   1. A new `is_<platform>` config_setting in //cuda:BUILD.bazel
 #   2. If the new platform shares cpu+os with another, a disambiguation
-#      mechanism (see :target_gpu and :is_linux_aarch64_or_sbsa for the
+#      mechanism (see :aarch64 and :is_linux_aarch64_or_sbsa for the
 #      aarch64 case)
-#   3. A new entry in this list (or in _AARCH64_FROM_TARGET_GPU below for
+#   3. A new entry in this list (or in _AARCH64_FROM_FLAG below for
 #      aarch64-only additions)
 # Without all three, the new platform will silently fall through to
 # :unsupported_cuda_platform with no diagnostic.
@@ -35,13 +35,13 @@ _AUTO_FROM_CONSTRAINT = [
     ("is_windows_x86_64", "windows-x86_64"),
 ]
 
-# Mapping from :target_gpu-flag config_settings to the aarch64-linux CUDA
+# Mapping from :aarch64-flag config_settings to the aarch64-linux CUDA
 # platform they resolve to. Drives the inner alias that disambiguates
 # linux-sbsa (server-class ARM, discrete GPU) from linux-aarch64 (Tegra/Drive
 # embedded, on-die GPU).
-_AARCH64_FROM_TARGET_GPU = [
-    ("target_gpu_is_discrete", "linux-sbsa"),
-    ("target_gpu_is_on_die", "linux-aarch64"),
+_AARCH64_FROM_FLAG = [
+    ("aarch64_is_sbsa", "linux-sbsa"),
+    ("aarch64_is_aarch64", "linux-aarch64"),
 ]
 
 def _platform_repos_attr(platform):
@@ -65,14 +65,14 @@ def _version_sort_key(version):
 def _emit_aarch64_inner_alias(build_content, alias_name, target_name, platforms_available, dummy_target):
     """Emit the private inner alias that disambiguates linux-sbsa vs linux-aarch64.
 
-    Keyed on the :target_gpu flag (discrete -> linux-sbsa, on_die ->
+    Keyed on the :aarch64 flag (sbsa -> linux-sbsa, aarch64 ->
     linux-aarch64). Referenced from the outer constraint-based alias when
     the active config's platform is aarch64-linux.
     """
     build_content.append("alias(")
     build_content.append('    name = "{}",'.format(alias_name))
     build_content.append("    actual = select({")
-    for setting, platform in _AARCH64_FROM_TARGET_GPU:
+    for setting, platform in _AARCH64_FROM_FLAG:
         platform_suffix = platform.replace("-", "_")
         build_content.append('        "@rules_cuda//cuda:{}":'.format(setting))
         if platform in platforms_available:
@@ -89,7 +89,7 @@ def _emit_outer_constraint_alias(build_content, alias_name, target_name, platfor
 
     Used directly for target components and as the auto-detection fallback
     for exec components. For aarch64-linux configs, routes to the private
-    :target_gpu-keyed inner alias passed as aarch64_inner_name. Constraint
+    :aarch64-keyed inner alias passed as aarch64_inner_name. Constraint
     check fires against the active config's platform (exec at cfg="exec",
     target otherwise) — RBE-safe.
     """
@@ -231,7 +231,7 @@ def _platform_alias_repo_impl(ctx):
             )
         else:
             # Target components: single outer alias keyed on @platforms
-            # constraints. --platforms is the primary knob; :target_gpu
+            # constraints. --platforms is the primary knob; :aarch64
             # picks the aarch64 variant in the inner alias.
             _emit_outer_constraint_alias(
                 build_content,

--- a/tests/integration/test_all.sh
+++ b/tests/integration/test_all.sh
@@ -41,9 +41,12 @@ set -ex
 
 redist_platform_args=()
 if [[ "$RUNNER_OS" == "Windows" ]] || [[ "$(uname -s 2>/dev/null)" =~ MINGW|MSYS|CYGWIN ]]; then
+    # Target redist is auto-detected from the Windows host platform's
+    # @platforms//os:windows + @platforms//cpu:x86_64 constraints. exec_platform
+    # is set defensively to guarantee the windows-x86_64 nvcc redist regardless
+    # of how the exec configuration's platform is declared.
     redist_platform_args=(
         --@rules_cuda//cuda:exec_platform=windows-x86_64
-        --@rules_cuda//cuda:target_platform=windows-x86_64
     )
 fi
 


### PR DESCRIPTION
## What changes

  - **New `--@rules_cuda//cuda:aarch64=sbsa|aarch64` flag** disambiguates `linux-sbsa` (server-class ARM, discrete GPU on PCIe — Grace, A4X, Graviton+GPU) from `linux-aarch64` (NVIDIA's Tegra/Jetson/Drive embedded redist with on-die GPU) when the active platform is aarch64-linux. Default is `sbsa` (linux-sbsa) — the safer fallback since the sbsa redist's libraries don't depend on Tegra-specific kernel modules. The flag is a no-op on x86   
  and Windows platforms, which are unambiguously identified by `@platforms//cpu` + `@platforms//os` alone.
                                                                                                                                              
  - **`target_platform` flag removed.** Fully replaced by `--platforms` + optional `--@rules_cuda//cuda:aarch64`.

After CUDA 13 or above, when Linux sbsa and aarch64 are unified, people no longer need to pass `--@rules_cuda//cuda:aarch64`. 
                                                                                                                                              
  ## Usage                                                                                                                                    
                                               
  ```
  # Vanilla linux-x86_64 — no extra flags needed.
  bazel build --platforms=//:my_x86_platform //:cuda_target                                                                                              
  
  # Server-class ARM (Grace, A4X, Graviton + dGPU).                                                                                                      
  # :aarch64 defaults to sbsa → resolves to linux-sbsa.                                                                                                  
  bazel build --platforms=//:my_aarch64_platform //:cuda_target                                                                                          
                                                                                                                                                         
  # Drive Thor / Jetson Tegra (on-die GPU).                                                                                                              
  bazel build --platforms=//:my_aarch64_platform \                                                                                                       
              --@rules_cuda//cuda:aarch64=aarch64 \                                                                                                      
              //:cuda_target                                                                                                                  
  ```                                                                                                                                                    
                                                                                                                                                         
  ## Breaking change                                                                                                                                     
                                                                                                                                                         
  `--@rules_cuda//cuda:target_platform=<plat>` is removed. Callers should switch to `--platforms` + `--@rules_cuda//cuda:aarch64` where needed:
                                                                                                                                                         
  | Before | After |                           
  |---|---|                                                                                                                                              
  | `--@rules_cuda//cuda:target_platform=linux-x86_64` | `--platforms=//:my_x86_platform` |
  | `--@rules_cuda//cuda:target_platform=linux-sbsa` | `--platforms=//:my_aarch64_platform` |                                                            
  | `--@rules_cuda//cuda:target_platform=linux-aarch64` | `--platforms=//:my_aarch64_platform --@rules_cuda//cuda:aarch64=aarch64` |                     
                                                                                                                                                         
  The flag was only introduced in #454 and hasn't shipped in a tagged release yet, so impact should be limited.                                
                                                                                                                                              
  ## Verified                                                                                                                                            
                                                                                     
  Built downstream against a real cross-compile setup (x86 host → x86 / ARM-server-class / Tegra targets) with all three target platforms resolving to the correct CUDA redist via `cquery`:                                                                                                                  
  
  | `--platforms` + flags | resolved `cuda_runtime` redist |                                                                                             
  |---|---|                                                                                                                                              
  | `//:linux_amd64` | `cuda_cudart_linux_x86_64_12_8_1` |                                                                                    
  | `//:linux_aarch64` (default `aarch64=sbsa`) | `cuda_cudart_linux_sbsa_12_8_1` |                                                                      
  | `//:linux_aarch64` + `aarch64=aarch64` | `cuda_cudart_linux_aarch64_12_8_1` |                                                                        
                                                                                                                                                         
  Per-platform `cuda_nvcc` binaries (CUDA 12.8.93) confirmed native to their declared platform — `linux-x86_64` is x86_64 ELF, `linux-sbsa` and `linux-aarch64` are both aarch64 ELF (different glibc versions, not interchangeable). Confirms the existing `platform_type = "exec"` classification for nvcc/nvvm is correct across all four supported platforms. 