### PR TITLE
Fail when unsupported platforms are specified

### DIFF
--- a/cuda/extensions.bzl
+++ b/cuda/extensions.bzl
@@ -125,6 +125,8 @@ def _register_redist_components(module_ctx, attr, component_entries):
     redist_ver = redist_json_helper.get_redist_version(module_ctx, attr, json_object)
 
     for platform in attr.platforms:
+        if platform not in SUPPORTED_PLATFORMS:
+            fail("platform {} not supported. Supported platforms: [{}]".format(platform, ", ".join(SUPPORTED_PLATFORMS)))
         component_specs = redist_json_helper.collect_specs(module_ctx, attr, platform, json_object, url)
         for spec in component_specs:
             repo_name = redist_json_helper.get_repo_name(module_ctx, spec)


### PR DESCRIPTION
I accidentally set my platform tag to `linux-x86-64` instead of `linux-x86_64`, along with `linux-sbsa`. This led to the build attempting to use aarch64 nvcc on an x86 host, because the 1 platform/version fallback would be hit, since the linux-x86-64 is an unsupported platform. This PR checks that all platforms specified are supported, avoiding the strange behaviour of using the wrong arch for the exec platform.
