### PR TITLE
Resolve cuda_toolkit in exec config

### DIFF
--- a/cuda/private/toolchain_configs/clang.bzl
+++ b/cuda/private/toolchain_configs/clang.bzl
@@ -625,7 +625,7 @@ cuda_toolchain_config = rule(
     doc = """This rule provides the predefined cuda toolchain configuration for Clang.""",
     implementation = _impl,
     attrs = {
-        "cuda_toolkit": attr.label(mandatory = True, providers = [CudaToolkitInfo], doc = "A target that provides a `CudaToolkitInfo`."),
+        "cuda_toolkit": attr.label(mandatory = True, providers = [CudaToolkitInfo], cfg = "exec", doc = "A target that provides a `CudaToolkitInfo`."),
         "toolchain_identifier": attr.string(values = ["clang"], mandatory = True),
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),  # legacy behaviour
     },


### PR DESCRIPTION
`cuda_toolchain.compiler_files` is gathered with `cfg = "exec"`, so the files materialized as inputs to CudaCompile actions live under `bazel-out/<exec>/bin/`. The clang toolchain config, however, derives `--cuda-path=` from `ctx.attr.cuda_toolkit[CudaToolkitInfo].libdevice` without specifying a config, so it picks up the target-config File object whose `dirname` points at `bazel-out/<target>/bin/`. When the CTK files are generated (e.g. a synthetic CUDA root that drops in wrappers next to real headers), the flag and the materialized inputs land at different paths and clang fails with "cannot find CUDA installation".

Match the toolchain's exec-config view of the CTK in the toolchain config rule so the rendered `--cuda-path` lines up with the inputs in the sandbox. Source-file CTKs are unaffected because source files are config-independent.