### PR TITLE
Fix Windows CI: pin the MSVC toolset 

### DIFF
--- a/.github/actions/Set-VSEnv.ps1
+++ b/.github/actions/Set-VSEnv.ps1
@@ -1,10 +1,28 @@
 param (
     [parameter(Mandatory = $false)]
-    [ValidateSet(2022, 2019, 2017)][int]$Version = 2019,
+    [ValidateSet(2022, 2019, 2017)][int]$Version = 2022,
 
     [parameter(Mandatory = $false)]
-    [ValidateSet("all", "x86", "x64")][String]$Arch = "x64"
+    [ValidateSet("all", "x86", "x64")][String]$Arch = "x64",
+
+    # Pin a specific MSVC toolset (major.minor, e.g. "14.40"). CUDA toolkits lag
+    # behind the newest MSVC, so we must not let Bazel auto-detect the latest VS
+    # on the runner (e.g. VS 2026 / MSVC 14.51 on the windows-2025 image, which
+    # nvcc's frontend cannot parse). Empty = use the VS default toolset.
+    [parameter(Mandatory = $false)]
+    [string]$ToolsetVersion = ""
 )
+
+$ErrorActionPreference = "Stop"
+
+# VS component id (for `setup.exe --add`) per pinned toolset. Extend as needed.
+$toolset_component = @{
+    "14.40" = "Microsoft.VisualStudio.Component.VC.14.40.17.10.x86.x64"
+    "14.41" = "Microsoft.VisualStudio.Component.VC.14.41.17.11.x86.x64"
+    "14.42" = "Microsoft.VisualStudio.Component.VC.14.42.17.12.x86.x64"
+    "14.43" = "Microsoft.VisualStudio.Component.VC.14.43.17.13.x86.x64"
+    "14.44" = "Microsoft.VisualStudio.Component.VC.14.44.17.14.x86.x64"
+}
 
 function Set-EnvFromCmdSet {
     [CmdletBinding()]
@@ -30,20 +48,60 @@ $version_range = switch ($Version) {
     2017 { '[15,16)' }
 }
 $info = &$vs_where -version $version_range -format json | ConvertFrom-Json
-$vs_env = @{
-    install_path = $info ? $info[0].installationPath : $null
-    all          = 'Common7\Tools\VsDevCmd.bat'
-    x64          = 'VC\Auxiliary\Build\vcvars64.bat'
-    x86          = 'VC\Auxiliary\Build\vcvars32.bat'
-}
+$install_path = $info ? $info[0].installationPath : $null
 
-if ( $null -eq $vs_env.install_path) {
+if ($null -eq $install_path) {
     Write-Host -ForegroundColor Red "Visual Studio $Version is not installed."
-    return
+    exit 1
 }
 
-$path = Join-Path $vs_env.install_path $vs_env.$Arch
+# Ensure the pinned toolset is installed; CI images may only ship the newest.
+if ($ToolsetVersion) {
+    $msvc_dir = Join-Path $install_path "VC\Tools\MSVC"
+    $have = Get-ChildItem $msvc_dir -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name.StartsWith("$ToolsetVersion.") }
+    if (-not $have) {
+        $component = $toolset_component[$ToolsetVersion]
+        if (-not $component) {
+            Write-Host -ForegroundColor Red "No known VS component id for MSVC toolset $ToolsetVersion; add it to `$toolset_component."
+            exit 1
+        }
+        Write-Host "MSVC toolset $ToolsetVersion not found; installing $component ..."
+        $installer = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe'
+        & $installer modify --installPath "$install_path" --add $component --quiet --norestart --nocache --wait
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host -ForegroundColor Red "Failed to install MSVC toolset $ToolsetVersion (exit $LASTEXITCODE)."
+            exit 1
+        }
+    }
+}
 
-C:/Windows/System32/cmd.exe /c "`"$path`" & set" | Set-EnvFromCmdSet
+$vc_script = switch ($Arch) {
+    "all" { 'Common7\Tools\VsDevCmd.bat' }
+    "x64" { 'VC\Auxiliary\Build\vcvars64.bat' }
+    "x86" { 'VC\Auxiliary\Build\vcvars32.bat' }
+}
+$path = Join-Path $install_path $vc_script
+$vcvars_arg = if ($ToolsetVersion) { " -vcvars_ver=$ToolsetVersion" } else { "" }
+
+C:/Windows/System32/cmd.exe /c "`"$path`"$vcvars_arg & set" | Set-EnvFromCmdSet
+
+if ($ToolsetVersion -and (-not $env:VCToolsVersion -or -not $env:VCToolsVersion.StartsWith("$ToolsetVersion."))) {
+    Write-Host -ForegroundColor Red "Requested MSVC toolset $ToolsetVersion but vcvars selected '$env:VCToolsVersion'."
+    exit 1
+}
+
 Set-Item -Force -Path "Env:\BAZEL_VC" -Value "$env:VCINSTALLDIR"
-Write-Host -ForegroundColor Green "Visual Studio $Version $Arch Command Prompt variables set."
+
+# Persist to subsequent workflow steps. `bazelisk build` runs in separate shells,
+# so the process-local env vars set above would be lost and Bazel would fall back
+# to auto-detecting the newest (unsupported) VS. Writing BAZEL_VC(_FULL_VERSION)
+# to $GITHUB_ENV pins Bazel's MSVC toolchain to the toolset selected here.
+if ($env:GITHUB_ENV) {
+    "BAZEL_VC=$env:VCINSTALLDIR" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+    if ($env:VCToolsVersion) {
+        "BAZEL_VC_FULL_VERSION=$env:VCToolsVersion" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+    }
+}
+
+Write-Host -ForegroundColor Green "Visual Studio $Version $Arch (MSVC $env:VCToolsVersion) environment set."

--- a/.github/actions/Set-VSEnv.ps1
+++ b/.github/actions/Set-VSEnv.ps1
@@ -5,12 +5,15 @@ param (
     [parameter(Mandatory = $false)]
     [ValidateSet("all", "x86", "x64")][String]$Arch = "x64",
 
-    # Pin a specific MSVC toolset (major.minor, e.g. "14.40"). CUDA toolkits lag
-    # behind the newest MSVC, so we must not let Bazel auto-detect the latest VS
-    # on the runner (e.g. VS 2026 / MSVC 14.51 on the windows-2025 image, which
-    # nvcc's frontend cannot parse). Empty = use the VS default toolset.
+    # Pin a specific MSVC toolset prefix, or an ordered comma-separated list of
+    # prefixes (major.minor, e.g. "14.44,14.43,14.42,14.41,14.40"). CUDA
+    # toolkits lag behind the newest MSVC, so we must not let Bazel auto-detect
+    # the latest VS on the runner (e.g. VS 2026 / MSVC 14.51 on the windows-2025
+    # image, which nvcc's frontend cannot parse). Defaults to VS 2022 14.4x
+    # candidates; pass "" to opt out and use the VS default toolset (not
+    # recommended in CI).
     [parameter(Mandatory = $false)]
-    [string]$ToolsetVersion = ""
+    [string]$ToolsetVersion = "14.44,14.43,14.42,14.41,14.40"
 )
 
 $ErrorActionPreference = "Stop"
@@ -22,6 +25,15 @@ $toolset_component = @{
     "14.42" = "Microsoft.VisualStudio.Component.VC.14.42.17.12.x86.x64"
     "14.43" = "Microsoft.VisualStudio.Component.VC.14.43.17.13.x86.x64"
     "14.44" = "Microsoft.VisualStudio.Component.VC.14.44.17.14.x86.x64"
+}
+
+function Get-InstalledMsvcToolsets {
+    [CmdletBinding()]
+    param([string]$InstallPath)
+
+    $msvc_dir = Join-Path $InstallPath "VC\Tools\MSVC"
+    Get-ChildItem $msvc_dir -Directory -ErrorAction SilentlyContinue |
+        Sort-Object Name -Descending
 }
 
 function Set-EnvFromCmdSet {
@@ -56,23 +68,51 @@ if ($null -eq $install_path) {
 }
 
 # Ensure the pinned toolset is installed; CI images may only ship the newest.
+$selected_toolset = ""
 if ($ToolsetVersion) {
-    $msvc_dir = Join-Path $install_path "VC\Tools\MSVC"
-    $have = Get-ChildItem $msvc_dir -Directory -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name.StartsWith("$ToolsetVersion.") }
-    if (-not $have) {
-        $component = $toolset_component[$ToolsetVersion]
+    $requested_toolsets = $ToolsetVersion.Split(",") |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ }
+
+    $installed_toolsets = @(Get-InstalledMsvcToolsets -InstallPath $install_path)
+    foreach ($candidate in $requested_toolsets) {
+        $match = $installed_toolsets |
+            Where-Object { $_.Name.StartsWith("$candidate.") } |
+            Select-Object -First 1
+        if ($match) {
+            $selected_toolset = $candidate
+            break
+        }
+    }
+
+    # If exactly one toolset was requested, try to install it. For candidate
+    # lists, fail with diagnostics instead of guessing which version to install.
+    if (-not $selected_toolset -and $requested_toolsets.Count -eq 1) {
+        $component = $toolset_component[$requested_toolsets[0]]
         if (-not $component) {
-            Write-Host -ForegroundColor Red "No known VS component id for MSVC toolset $ToolsetVersion; add it to `$toolset_component."
+            Write-Host -ForegroundColor Red "No known VS component id for MSVC toolset $($requested_toolsets[0]); add it to `$toolset_component."
             exit 1
         }
-        Write-Host "MSVC toolset $ToolsetVersion not found; installing $component ..."
+        Write-Host "MSVC toolset $($requested_toolsets[0]) not found; installing $component ..."
         $installer = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\setup.exe'
         & $installer modify --installPath "$install_path" --add $component --quiet --norestart --nocache --wait
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host -ForegroundColor Red "Failed to install MSVC toolset $ToolsetVersion (exit $LASTEXITCODE)."
+        if ($LASTEXITCODE -notin @(0, 3010)) {
+            Write-Host -ForegroundColor Red "Failed to install MSVC toolset $($requested_toolsets[0]) (exit $LASTEXITCODE)."
             exit 1
         }
+        $installed_toolsets = @(Get-InstalledMsvcToolsets -InstallPath $install_path)
+        $match = $installed_toolsets |
+            Where-Object { $_.Name.StartsWith("$($requested_toolsets[0]).") } |
+            Select-Object -First 1
+        if ($match) {
+            $selected_toolset = $requested_toolsets[0]
+        }
+    }
+
+    if (-not $selected_toolset) {
+        $available = if ($installed_toolsets) { ($installed_toolsets.Name -join ", ") } else { "<none>" }
+        Write-Host -ForegroundColor Red "None of the requested MSVC toolsets were found: $($requested_toolsets -join ', '). Available toolsets: $available"
+        exit 1
     }
 }
 
@@ -82,12 +122,12 @@ $vc_script = switch ($Arch) {
     "x86" { 'VC\Auxiliary\Build\vcvars32.bat' }
 }
 $path = Join-Path $install_path $vc_script
-$vcvars_arg = if ($ToolsetVersion) { " -vcvars_ver=$ToolsetVersion" } else { "" }
+$vcvars_arg = if ($selected_toolset) { " -vcvars_ver=$selected_toolset" } else { "" }
 
 C:/Windows/System32/cmd.exe /c "`"$path`"$vcvars_arg & set" | Set-EnvFromCmdSet
 
-if ($ToolsetVersion -and (-not $env:VCToolsVersion -or -not $env:VCToolsVersion.StartsWith("$ToolsetVersion."))) {
-    Write-Host -ForegroundColor Red "Requested MSVC toolset $ToolsetVersion but vcvars selected '$env:VCToolsVersion'."
+if ($selected_toolset -and (-not $env:VCToolsVersion -or -not $env:VCToolsVersion.StartsWith("$selected_toolset."))) {
+    Write-Host -ForegroundColor Red "Requested MSVC toolset $selected_toolset but vcvars selected '$env:VCToolsVersion'."
     exit 1
 }
 

--- a/.github/actions/set-build-env/action.yaml
+++ b/.github/actions/set-build-env/action.yaml
@@ -80,4 +80,10 @@ runs:
     - name: Set Visual Studio Environment (Windows)
       if: ${{ startsWith(inputs.os, 'windows') }}
       shell: pwsh
-      run: .github/actions/Set-VSEnv.ps1 2019
+      # Pin the MSVC toolset instead of letting Bazel auto-detect the newest VS
+      # on the runner. The windows-2025 image now ships VS 2026 / MSVC 14.51,
+      # which nvcc's frontend cannot parse (STL static_assert failures) for the
+      # CUDA versions under test. MSVC 14.40 (VS 17.10) is within CUDA 12.6/13.0's
+      # supported host-compiler range, and works for 11.5.2 via the
+      # -allow-unsupported-compiler flag already set in the build config.
+      run: .github/actions/Set-VSEnv.ps1 -Version 2022 -ToolsetVersion 14.40

--- a/.github/actions/set-build-env/action.yaml
+++ b/.github/actions/set-build-env/action.yaml
@@ -83,7 +83,7 @@ runs:
       # Pin the MSVC toolset instead of letting Bazel auto-detect the newest VS
       # on the runner. The windows-2025 image now ships VS 2026 / MSVC 14.51,
       # which nvcc's frontend cannot parse (STL static_assert failures) for the
-      # CUDA versions under test. MSVC 14.40 (VS 17.10) is within CUDA 12.6/13.0's
-      # supported host-compiler range, and works for 11.5.2 via the
-      # -allow-unsupported-compiler flag already set in the build config.
-      run: .github/actions/Set-VSEnv.ps1 -Version 2022 -ToolsetVersion 14.40
+      # CUDA versions under test. Select an installed VS 2022 14.4x toolset
+      # instead; if none are present, fail with diagnostics rather than falling
+      # back to an unsupported newer compiler.
+      run: .github/actions/Set-VSEnv.ps1 -Version 2022 -ToolsetVersion '14.44,14.43,14.42,14.41,14.40'


### PR DESCRIPTION
`Set-VSEnv.ps1` targeted VS 2019 (absent on current runners) and only set process-local env, so bazelisk build steps fell back to Bazel's MSVC auto-detection. The windows-2025 image now ships VS 2026 / MSVC 14.51, which nvcc can't parse (STL static_assert failures) for CUDA 12.6/13.0. Pin VS 2022 + MSVC 14.40 and persist BAZEL_VC/BAZEL_VC_FULL_VERSION to `$GITHUB_ENV`; install the toolset if the image lacks it; fail loudly on drift. 