### PR TITLE
feat: move CUDA RDC device runtime libs into the toolchain

### DIFF
--- a/cuda/private/actions/dlink.bzl
+++ b/cuda/private/actions/dlink.bzl
@@ -65,6 +65,8 @@ def _compiler_device_link(
     )
     host_compiler = cc_common.get_tool_for_action(feature_configuration = cc_feature_configuration, action_name = CC_ACTION_NAMES.cpp_compile)
     cuda_compiler = cuda_toolchain.compiler_executable
+    cuda_toolkit = find_cuda_toolkit(ctx)
+    device_runtime_static_libs = cuda_toolkit.device_runtime_static_libs
 
     artifact_category_name = cuda_helper.get_artifact_category_from_action(ACTION_NAMES.device_link, pic, rdc)
     basename = ctx.attr.name + "_dlink"
@@ -91,12 +93,13 @@ def _compiler_device_link(
     args = actions.args()
     args.add_all(cmd)
     args.add_all(objects)
+    args.add_all(device_runtime_static_libs)
 
     actions.run(
         executable = cuda_compiler,
         arguments = [args],
         outputs = [obj_file],
-        inputs = depset(transitive = [objects, cc_toolchain.all_files, cuda_toolchain.all_files]),
+        inputs = depset(transitive = [objects, device_runtime_static_libs, cc_toolchain.all_files, cuda_toolchain.all_files]),
         env = env,
         mnemonic = "CudaDeviceLink",
         progress_message = "Device linking %{output}",
@@ -117,6 +120,7 @@ def _wrapper_device_link(
         fail("device link is only meaningful on building relocatable device code")
 
     cuda_toolkit = find_cuda_toolkit(ctx)
+    device_runtime_static_libs = cuda_toolkit.device_runtime_static_libs
 
     actions = ctx.actions
     pic_suffix = "_pic" if pic else ""
@@ -128,6 +132,7 @@ def _wrapper_device_link(
     images = []
     obj_args = actions.args()
     obj_args.add_all(objects)
+    obj_args.add_all(device_runtime_static_libs)
     if len(common.cuda_archs_info.arch_specs) == 0:
         fail('cuda toolchain "' + cuda_toolchain.name + '" is configured to enable feature supports_wrapper_device_link,' +
              " at least one cuda arch must be specified.")
@@ -145,7 +150,7 @@ def _wrapper_device_link(
             cubin = ctx.actions.declare_file("_dlink{suffix}/{0}/{0}_{1}.cubin".format(ctx.attr.name, arch, suffix = pic_suffix))
             ctx.actions.run(
                 outputs = [register_h, cubin],
-                inputs = objects,
+                inputs = depset(transitive = [objects, device_runtime_static_libs]),
                 executable = cuda_toolkit.nvlink,
                 arguments = [
                     "--arch=" + arch,

--- a/cuda/private/providers.bzl
+++ b/cuda/private/providers.bzl
@@ -113,6 +113,7 @@ CudaToolkitInfo = provider(
         "cicc": "File to the cicc executable",
         "ptxas": "File to the ptxas executable",
         "libdevice": "File to the libdevice LLVM bitcode library (libdevice.10.bc)",
+        "device_runtime_static_libs": "A depset of static libraries needed for RDC device link and final host link.",
     },
 )
 

--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -45,6 +45,12 @@ def _get_nvcc_version(repository_ctx, nvcc_root):
             return version[:2]
     return [-1, -1]
 
+def _find_local_cuda_file_label(repository_ctx, cuda_path, relative_paths):
+    for relative_path in relative_paths:
+        if repository_ctx.path(cuda_path + "/" + relative_path).exists:
+            return str(Label("@cuda//:cuda/{}".format(relative_path)))
+    return None
+
 def _detect_local_cuda_toolkit(repository_ctx):
     cuda_path = repository_ctx.attr.toolkit_path
     if cuda_path == "":
@@ -73,6 +79,7 @@ def _detect_local_cuda_toolkit(repository_ctx):
     bin2c = "@rules_cuda//cuda/dummy:bin2c"
     fatbinary = "@rules_cuda//cuda/dummy:fatbinary"
     ptxas = "@rules_cuda//cuda/dummy:ptxas"
+    device_runtime_static_libs_labels = []
     if cuda_path != None:
         if repository_ctx.path(cuda_path + "/bin/nvcc" + bin_ext).exists:
             nvcc = str(Label("@cuda//:cuda/bin/nvcc{}".format(bin_ext)))
@@ -86,6 +93,20 @@ def _detect_local_cuda_toolkit(repository_ctx):
             fatbinary = str(Label("@cuda//:cuda/bin/fatbinary{}".format(bin_ext)))
         if repository_ctx.path(cuda_path + "/bin/ptxas" + bin_ext).exists:
             ptxas = str(Label("@cuda//:cuda/bin/ptxas{}".format(bin_ext)))
+        if _is_windows(repository_ctx):
+            cudadevrt = _find_local_cuda_file_label(repository_ctx, cuda_path, [
+                "lib/x64/cudadevrt.lib",
+                "lib/cudadevrt.lib",
+            ])
+            if cudadevrt:
+                device_runtime_static_libs_labels.append(cudadevrt)
+        elif _is_linux(repository_ctx):
+            for lib_label in [
+                _find_local_cuda_file_label(repository_ctx, cuda_path, ["lib64/libcudadevrt.a"]),
+                _find_local_cuda_file_label(repository_ctx, cuda_path, ["lib64/libculibos.a"]),
+            ]:
+                if lib_label:
+                    device_runtime_static_libs_labels.append(lib_label)
 
     nvcc_version_major = -1
     nvcc_version_minor = -1
@@ -109,6 +130,7 @@ def _detect_local_cuda_toolkit(repository_ctx):
         ptxas_label = ptxas,
         cicc_label = None,  # local CTK do not need this
         libdevice_label = None,  # local CTK do not need this
+        device_runtime_static_libs_labels = device_runtime_static_libs_labels,
     )
 
 def _detect_deliverable_cuda_toolkit(repository_ctx):
@@ -139,6 +161,19 @@ def _detect_deliverable_cuda_toolkit(repository_ctx):
     bin2c = "{}//:bin2c".format(nvcc_repo)
     fatbinary = "{}//:fatbinary".format(nvcc_repo)
     ptxas = "{}//:ptxas".format(nvcc_repo)
+    device_runtime_static_libs_labels = []
+
+    cudart_repo = repository_ctx.attr.components_mapping["cudart"]
+    if _is_windows(repository_ctx):
+        device_runtime_static_libs_labels.append("{}//:cudadevrt_lib".format(cudart_repo))
+    else:
+        device_runtime_static_libs_labels.append("{}//:cudadevrt_a".format(cudart_repo))
+        if int(cuda_version_major) >= 13:
+            culibos_repo = repository_ctx.attr.components_mapping.get("culibos")
+            if culibos_repo:
+                device_runtime_static_libs_labels.append("{}//:culibos_a".format(culibos_repo))
+        else:
+            device_runtime_static_libs_labels.append("{}//:culibos_a".format(cudart_repo))
 
     cicc = None
     libdevice = None
@@ -161,6 +196,7 @@ def _detect_deliverable_cuda_toolkit(repository_ctx):
         ptxas_label = ptxas,
         cicc_label = cicc,
         libdevice_label = libdevice,
+        device_runtime_static_libs_labels = device_runtime_static_libs_labels,
     )
 
 def detect_cuda_toolkit(repository_ctx):

--- a/cuda/private/rules/cuda_library.bzl
+++ b/cuda/private/rules/cuda_library.bzl
@@ -6,7 +6,26 @@ load("//cuda/private:actions/dlink.bzl", "device_link")
 load("//cuda/private:cuda_helper.bzl", "cuda_helper")
 load("//cuda/private:providers.bzl", "CudaInfo")
 load("//cuda/private:rules/common.bzl", "ALLOW_CUDA_HDRS", "ALLOW_CUDA_SRCS")
-load("//cuda/private:toolchain.bzl", "find_cuda_toolchain", "use_cuda_toolchain")
+load("//cuda/private:toolchain.bzl", "find_cuda_toolchain", "find_cuda_toolkit", "use_cuda_toolchain")
+
+def _create_device_runtime_linking_context(ctx, cc_toolchain, feature_configuration, device_runtime_static_libs):
+    libraries = [
+        cc_common.create_library_to_link(
+            actions = ctx.actions,
+            cc_toolchain = cc_toolchain,
+            feature_configuration = feature_configuration,
+            static_library = static_lib,
+        )
+        for static_lib in device_runtime_static_libs.to_list()
+    ]
+    if not libraries:
+        return None
+
+    linker_input = cc_common.create_linker_input(
+        owner = ctx.label,
+        libraries = depset(libraries),
+    )
+    return cc_common.create_linking_context(linker_inputs = depset([linker_input]))
 
 def _cuda_library_impl(ctx):
     """cuda_library is a rule that perform device link.
@@ -99,6 +118,17 @@ def _cuda_library_impl(ctx):
         requested_features = ctx.features,
         unsupported_features = ctx.disabled_features,
     )
+    linking_contexts = list(common.transitive_linking_contexts)
+    if use_rdc:
+        device_runtime_linking_context = _create_device_runtime_linking_context(
+            ctx,
+            cc_toolchain,
+            cc_feature_config,
+            find_cuda_toolkit(ctx).device_runtime_static_libs,
+        )
+        if device_runtime_linking_context != None:
+            linking_contexts.append(device_runtime_linking_context)
+
     linking_ctx, linking_outputs = cc_common.create_linking_context_from_compilation_outputs(
         name = ctx.attr.name,
         actions = ctx.actions,
@@ -107,7 +137,7 @@ def _cuda_library_impl(ctx):
         compilation_outputs = cc_common.create_compilation_outputs(objects = archive_content, pic_objects = pic_archive_content),
         user_link_flags = common.host_link_flags,
         alwayslink = attr.alwayslink,
-        linking_contexts = common.transitive_linking_contexts,
+        linking_contexts = linking_contexts,
         disallow_dynamic_library = True,
     )
 

--- a/cuda/private/rules/cuda_toolkit_info.bzl
+++ b/cuda/private/rules/cuda_toolkit_info.bzl
@@ -3,6 +3,10 @@ load("//cuda/private:providers.bzl", "CudaToolkitInfo")
 def _impl(ctx):
     version_major, version_minor = ctx.attr.version.split(".")[:2]
     expanded_path = ctx.expand_location(ctx.attr.path, ctx.attr.path_data)
+    device_runtime_static_libs = depset(transitive = [
+        target[DefaultInfo].files
+        for target in ctx.attr.device_runtime_static_libs
+    ])
 
     return CudaToolkitInfo(
         path = expanded_path,
@@ -15,6 +19,7 @@ def _impl(ctx):
         ptxas = ctx.file.ptxas,
         cicc = ctx.file.cicc,
         libdevice = ctx.file.libdevice,
+        device_runtime_static_libs = device_runtime_static_libs,
     )
 
 cuda_toolkit_info = rule(
@@ -31,6 +36,7 @@ cuda_toolkit_info = rule(
         "ptxas": attr.label(allow_single_file = True, doc = "The ptxas executable."),
         "cicc": attr.label(default = None, allow_single_file = True, doc = "The cicc executable."),
         "libdevice": attr.label(default = None, allow_single_file = True, doc = "The libdevice LLVM bitcode library."),
+        "device_runtime_static_libs": attr.label_list(allow_files = True, doc = "Static libraries needed for RDC device link and final host link."),
     },
     provides = [CudaToolkitInfo],
 )

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -54,6 +54,11 @@ def _expand_dctk_component(repository_ctx, component):
     }
     return _expand_template(repository_ctx, tpl_label, substitutions = substitutions)
 
+def _component_owns_cuda_repo_alias(component, target, components):
+    if target == "culibos_a" and "culibos" in components:
+        return component == "culibos"
+    return True
+
 def _generate_build_impl(repository_ctx, libpath, components, is_cuda_repo, is_deliverable):
     # stitch template fragment
     fragments = [
@@ -85,6 +90,8 @@ def _generate_build_impl(repository_ctx, libpath, components, is_cuda_repo, is_d
     if is_cuda_repo and is_deliverable:  # generate `@cuda//BUILD` for CTK with deliverables
         for comp in components:
             for target in REGISTRY[comp]:
+                if not _component_owns_cuda_repo_alias(comp, target, components):
+                    continue
                 repo = components[comp]
                 line = 'alias(name = "{target}", actual = "{repo}//:{target}")'.format(target = target, repo = repo)
                 template_content.append(line)
@@ -196,9 +203,11 @@ def _generate_toolchain_build(repository_ctx, cuda):
     if cuda.libdevice_label != None:
         compiler_files.append(cuda.libdevice_label)
     compiler_files_line = "compiler_files = " + repr(compiler_files) + ","
+    device_runtime_static_libs_line = "device_runtime_static_libs = " + repr(cuda.device_runtime_static_libs_labels) + ","
 
     substitutions = {
         "# %{compiler_files_line}": compiler_files_line,
+        "# %{device_runtime_static_libs_line}": device_runtime_static_libs_line,
         "%{cuda_path}": _to_forward_slash(cuda.path) if cuda.path else "cuda-not-found",
         "%{cuda_version}": "{}.{}".format(cuda.version_major, cuda.version_minor),
         "%{nvcc_version_major}": str(cuda.nvcc_version_major),
@@ -264,10 +273,12 @@ def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
             ])
     path_data_line = "path_data = " + repr(path_data) + ","
     compiler_files_line = "compiler_files = " + repr(compiler_files) + ","
+    device_runtime_static_libs_line = "device_runtime_static_libs = " + repr(cuda.device_runtime_static_libs_labels) + ","
 
     substitutions = {
         "# %{compiler_attribute_line}": compiler_attr_line,
         "# %{compiler_files_line}": compiler_files_line,
+        "# %{device_runtime_static_libs_line}": device_runtime_static_libs_line,
         "%{clang_path}": clang_path_for_subst,  # Will be empty if label is used
         "%{clang_label}": clang_label_for_subst,  # Will be empty if path is used
         "%{cuda_path}": cuda_path_for_subst,

--- a/cuda/private/templates/BUILD.cudart
+++ b/cuda/private/templates/BUILD.cudart
@@ -9,21 +9,28 @@ cc_library(
     target_compatible_with = ["@platforms//os:linux"],
 )
 
-# NOTE: for cuda toolkit older than 13.0, culibos_a is defined here, BUILD.culibos otherwise.
+# Local CUDA 13+ expands BUILD.culibos into this package, where it owns the real
+# culibos_a target. Component repos still need this cudart-owned target so
+# version/platform aliases can expose a stable target set.
 [
     cc_library(
         name = "culibos_a",
-        srcs = ["%{component_name}/%{libpath}/libculibos.a"],
+        srcs = if_cuda_toolkit_version_ge(
+            (13, 0),
+            [],
+            ["%{component_name}/%{libpath}/libculibos.a"],
+        ),
         target_compatible_with = ["@platforms//os:linux"],
     )
-    for name in if_cuda_toolkit_version_ge((13,0), [], ["culibos"])
+    for name in if_cuda_toolkit_version_ge(
+        (13, 0),
+        if_local_cuda_toolkit(
+            [],
+            ["culibos"],
+        ),
+        ["culibos"],
+    )
 ]
-
-conditional_culibos_a = if_cuda_toolkit_version_ge(
-  (13,0),
-  if_local_cuda_toolkit([":culibos_a"], ["@cuda//:culibos_a"]),
-  [":culibos_a"],
-)
 
 cc_import(
     name = "cudart_lib",
@@ -57,11 +64,9 @@ cc_library(
     deps = additional_header_deps("cudart") + [
         ":%{component_name}_headers",
     ] + if_linux([
-        # devrt is required for jit linking when rdc is enabled
-        ":cudadevrt_a",
         ":cudart_so",
-    ] + conditional_culibos_a) + if_windows([
-        # devrt is required for jit linking when rdc is enabled
+    ]) + if_windows([
+        # CUDA's Windows runtime link interface includes cudadevrt.lib.
         ":cudadevrt_lib",
         ":cudart_lib",
     ]),

--- a/cuda/private/templates/BUILD.toolchain_clang
+++ b/cuda/private/templates/BUILD.toolchain_clang
@@ -13,10 +13,11 @@ cuda_toolkit_info(
     fatbinary = "%{fatbinary_label}",
     link_stub = "%{link_stub_label}",
     nvlink = "%{nvlink_label}",
-    ptxas = "%{ptxas_label}",
     # %{cicc_line},
     # %{libdevice_line},
+    # %{device_runtime_static_libs_line}
     path = "%{cuda_path}",
+    ptxas = "%{ptxas_label}",
     # %{path_data_line}
     version = "%{cuda_version}",
 )

--- a/cuda/private/templates/BUILD.toolchain_nvcc
+++ b/cuda/private/templates/BUILD.toolchain_nvcc
@@ -13,10 +13,11 @@ cuda_toolkit_info(
     fatbinary = "%{fatbinary_label}",
     link_stub = "%{link_stub_label}",
     nvlink = "%{nvlink_label}",
-    ptxas = "%{ptxas_label}",
     # %{cicc_line},
     # %{libdevice_line},
+    # %{device_runtime_static_libs_line}
     path = "%{cuda_path}",
+    ptxas = "%{ptxas_label}",
     version = "%{cuda_version}",
 )
 

--- a/cuda/private/templates/BUILD.toolchain_nvcc_msvc
+++ b/cuda/private/templates/BUILD.toolchain_nvcc_msvc
@@ -13,10 +13,11 @@ cuda_toolkit_info(
     fatbinary = "%{fatbinary_label}",
     link_stub = "%{link_stub_label}",
     nvlink = "%{nvlink_label}",
-    ptxas = "%{ptxas_label}",
     # %{cicc_line},
     # %{libdevice_line},
+    # %{device_runtime_static_libs_line}
     path = "%{cuda_path}",
+    ptxas = "%{ptxas_label}",
     version = "%{cuda_version}",
 )
 

--- a/cuda/private/templates/registry.bzl
+++ b/cuda/private/templates/registry.bzl
@@ -1,6 +1,6 @@
 # map short component name to consumable targets
 REGISTRY = {
-    "cudart": ["cudart_all_files", "cudart_license", "cudart_headers", "cuda", "cuda_runtime", "cuda_runtime_static"],
+    "cudart": ["cudart_all_files", "cudart_license", "cudart_headers", "cuda", "cuda_runtime", "cuda_runtime_static", "cudadevrt_a", "cudadevrt_lib", "culibos_a"],  # device-runtime targets are not for end users.
     "nvcc": ["nvcc_all_files", "nvcc_license", "nvcc_headers", "compiler_root", "compiler_deps", "nvptxcompiler", "nvcc", "nvlink", "ptxas", "bin2c", "fatbinary", "link.stub"],
     "nvvm": ["nvvm_all_files", "nvvm_license", "nvvm_headers", "cicc", "libdevice", "libdevice.10.bc"],
     "cccl": ["cccl_all_files", "cccl_license", "cccl_headers", "libcudacxx", "cub", "thrust"],


### PR DESCRIPTION
# Move CUDA RDC device runtime libs into the toolchain

## Summary

This change removes unconditional propagation of CUDA device runtime static archives from the normal CUDA runtime dependency and moves them into the CUDA toolchain.

The goal is to let non-RDC consumers of `@rules_cuda//cuda:runtime` keep linking against shared `libcudart` without also pulling `libcudadevrt.a` / `libculibos.a` into downstream shared libraries. RDC builds still receive those static archives from the toolchain for device-link and final host-link correctness.

## Changes

- Adds `device_runtime_static_libs` to `CudaToolkitInfo`.
- Discovers local toolkit `libcudadevrt.a` / `libculibos.a` and generated redist aliases as CUDA toolchain inputs.
- Adds the device runtime static archives to CUDA device-link actions.
- Propagates device runtime static archives into final C++ linking only for `cuda_library(rdc = True)`.
- Removes `cudadevrt_a` / `culibos_a` from the normal dynamic `cuda_runtime` dependency path on Linux.
- Preserves Windows dynamic-runtime link behavior, where CUDA’s runtime import-library interface includes `cudadevrt.lib`.
- Exposes device-runtime component targets needed by generated toolchains.
- Handles CUDA 13+ `culibos` ownership for both local toolkits and redist-generated alias repos so `culibos_a` is emitted once and resolves to the component that owns the archive.

## Validation

Rules CUDA:

```sh
bazel test //tests/flag:cuda_library_dlink_copts_and_host_copts_flag_test
bazel build @rules_cuda_examples//rdc:main_from_library
bazel build @rules_cuda_examples//basic:main
```

Link-shape checks:

```sh
bazel aquery --noshow_progress 'mnemonic("CppLink", @rules_cuda_examples//basic:main)' --output=text
bazel aquery --noshow_progress 'mnemonic("CppLink", @rules_cuda_examples//rdc:main_from_library)' --output=text
```

- Non-RDC `basic:main` final link uses shared `libcudart` and does not include `libcudadevrt.a`, `libculibos.a`, or `libcudart_static.a`.
- RDC `rdc:main_from_library` final link includes `libcudadevrt.a` and `libculibos.a` from the CUDA toolchain.

Downstream smoke validation:

```sh
bazel build --override_module=rules_cuda=/home/csaint/nv/csaint/rules_cuda \
  :visual_global_localization_node_so
```

The representative shared library `libvisual_global_localization_node.so` dropped to about 20 MB, and the package SO link params used shared `libcudart.so.13` without `cudadevrt`, `culibos`, or `cudart_static` entries.
