### PR TITLE
fix: report the selected CUDA version, not the maximum declared one

### DIFF
--- a/cuda/extensions.bzl
+++ b/cuda/extensions.bzl
@@ -248,10 +248,22 @@ def _impl(module_ctx):
 
     for _, toolkit in registrations.items():
         if components_mapping != None:
+            sorted_redist_versions = sorted(redist_versions, key = _version_sort_key)
+
             # Always use the maximum version so the toolkit includes all components.
             # Components that don't exist in older versions will fall back to dummy.
-            toolkit_version = sorted(redist_versions, key = _version_sort_key)[-1]
-            cuda_toolkit(name = toolkit.name, components_mapping = components_mapping, version = toolkit_version)
+            toolkit_version = sorted_redist_versions[-1]
+
+            # All declared versions are passed along so that the generated toolchain can
+            # select the version matching @rules_cuda//cuda:version. Without it the
+            # toolchain would report `toolkit_version` regardless of which nvcc the
+            # component aliases actually resolve to.
+            cuda_toolkit(
+                name = toolkit.name,
+                components_mapping = components_mapping,
+                version = toolkit_version,
+                toolkit_versions = sorted_redist_versions,
+            )
         else:
             cuda_toolkit(**_module_tag_to_dict(toolkit))
 

--- a/cuda/private/repositories.bzl
+++ b/cuda/private/repositories.bzl
@@ -349,6 +349,12 @@ cuda_toolkit = repository_rule(
         "nvcc_version": attr.string(
             doc = "nvcc version. Required for deliverable toolkit only. Fallback to version if omitted.",
         ),
+        "toolkit_versions": attr.string_list(
+            doc = "All cuda toolkit versions reachable through the component aliases, i.e. every " +
+                  "version declared with `cuda.redist_json`. When more than one is present, the " +
+                  "generated toolchain selects among them on @rules_cuda//cuda:version instead of " +
+                  "hardcoding `version`.",
+        ),
     },
     configure = True,
     local = True,

--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -18,6 +18,108 @@ def _expand_template(repository_ctx, tpl_label, substitutions):
         template_content = template_content.replace(k, v)
     return template_content
 
+def _version_label(version):
+    return version.replace(".", "_").replace("-", "_")
+
+def _major_minor(version):
+    """Split a version into its (major, minor) pair, or None if it has neither.
+
+    Args:
+        version: A version string such as "12.8.1" or "11.5.1-1ubuntu1".
+
+    Returns:
+        A (major, minor) tuple of strings, or None if `version` is not of that shape.
+    """
+    parts = version.split("-", 1)[0].split(".")
+    if len(parts) < 2 or not parts[0].isdigit() or not parts[1].isdigit():
+        return None
+    return (parts[0], parts[1])
+
+def _versions_to_select_on(toolkit_versions):
+    """The versions a toolchain attribute can be selected on.
+
+    A single version needs no select at all, and one whose major/minor cannot be parsed
+    has nothing to compare against `--@rules_cuda//cuda:version`, so both are dropped.
+
+    Args:
+        toolkit_versions: Every version declared with `cuda.redist_json`.
+
+    Returns:
+        The versions to emit a select branch for, or [] to keep the attribute a literal.
+    """
+    if not toolkit_versions or len(toolkit_versions) < 2:
+        return []
+    return [v for v in toolkit_versions if _major_minor(v) != None]
+
+def _version_config_settings(toolkit_versions):
+    """config_settings matching `--@rules_cuda//cuda:version`, one per declared version.
+
+    Emitted into the same package as the selects that read them.
+
+    Args:
+        toolkit_versions: The versions returned by `_versions_to_select_on`.
+
+    Returns:
+        The config_setting definitions, or "" when no select is needed.
+    """
+    if not toolkit_versions:
+        return ""
+
+    lines = []
+    for version in toolkit_versions:
+        lines.extend([
+            "config_setting(",
+            '    name = "toolkit_version_is_{}",'.format(_version_label(version)),
+            '    flag_values = {{"@rules_cuda//cuda:version": "{}"}},'.format(version),
+            ")",
+            "",
+        ])
+    return "\n".join(lines).rstrip("\n")
+
+def _substitute_version_config_settings(substitutions, toolkit_versions):
+    """Add the config_setting substitution, keyed so an empty value leaves no blank line.
+
+    The placeholder sits on its own line in the template. Substituting an empty string
+    would leave that line blank, so when there is nothing to emit the surrounding newlines
+    are consumed along with it.
+
+    Args:
+        substitutions: The substitution dict to add to.
+        toolkit_versions: The versions returned by `_versions_to_select_on`.
+    """
+    config_settings = _version_config_settings(toolkit_versions)
+    if config_settings:
+        substitutions["# %{toolkit_version_config_settings}"] = config_settings
+    else:
+        substitutions["\n# %{toolkit_version_config_settings}\n"] = ""
+
+def _version_select(attr_name, toolkit_versions, value_of_version, default_value):
+    """An attribute assignment selecting its value on the active CUDA version.
+
+    Args:
+        attr_name: Name of the attribute to assign.
+        toolkit_versions: The versions returned by `_versions_to_select_on`.
+        value_of_version: Callback mapping a version to its already-quoted attribute value.
+        default_value: Already-quoted value used when `cuda:version` is unset, which
+            leaves the toolchain reporting the same version the component aliases
+            resolve to by default (the maximum declared one).
+
+    Returns:
+        Either `attr = <default>,` or `attr = select({...}),`.
+    """
+    if not toolkit_versions:
+        return "{} = {},".format(attr_name, default_value)
+
+    lines = ["{} = select({{".format(attr_name)]
+    for version in toolkit_versions:
+        lines.append('    ":toolkit_version_is_{}": {},'.format(
+            _version_label(version),
+            value_of_version(version),
+        ))
+    lines.append('    "//conditions:default": {},'.format(default_value))
+    lines.append("}),")
+    return "\n    ".join(lines)
+
 def _expand_lctk_cuda(repository_ctx, components):
     tpl_label = Label("//cuda/private:templates/BUILD.lctk_cuda")
     substitutions = {
@@ -205,13 +307,29 @@ def _generate_toolchain_build(repository_ctx, cuda):
     compiler_files_line = "compiler_files = " + repr(compiler_files) + ","
     device_runtime_static_libs_line = "device_runtime_static_libs = " + repr(cuda.device_runtime_static_libs_labels) + ","
 
+    select_versions = _versions_to_select_on(repository_ctx.attr.toolkit_versions)
     substitutions = {
         "# %{compiler_files_line}": compiler_files_line,
         "# %{device_runtime_static_libs_line}": device_runtime_static_libs_line,
         "%{cuda_path}": _to_forward_slash(cuda.path) if cuda.path else "cuda-not-found",
-        "%{cuda_version}": "{}.{}".format(cuda.version_major, cuda.version_minor),
-        "%{nvcc_version_major}": str(cuda.nvcc_version_major),
-        "%{nvcc_version_minor}": str(cuda.nvcc_version_minor),
+        "# %{cuda_version_line}": _version_select(
+            "version",
+            select_versions,
+            lambda v: '"{}.{}"'.format(*_major_minor(v)),
+            '"{}.{}"'.format(cuda.version_major, cuda.version_minor),
+        ),
+        "# %{nvcc_version_major_line}": _version_select(
+            "nvcc_version_major",
+            select_versions,
+            lambda v: _major_minor(v)[0],
+            str(cuda.nvcc_version_major),
+        ),
+        "# %{nvcc_version_minor_line}": _version_select(
+            "nvcc_version_minor",
+            select_versions,
+            lambda v: _major_minor(v)[1],
+            str(cuda.nvcc_version_minor),
+        ),
         "%{nvcc_label}": cuda.nvcc_label,
         "%{nvlink_label}": cuda.nvlink_label,
         "%{link_stub_label}": cuda.link_stub_label,
@@ -223,6 +341,7 @@ def _generate_toolchain_build(repository_ctx, cuda):
         substitutions["# %{cicc_line}"] = "cicc = " + repr(cuda.cicc_label)
     if cuda.libdevice_label:
         substitutions["# %{libdevice_line}"] = "libdevice = " + repr(cuda.libdevice_label)
+    _substitute_version_config_settings(substitutions, select_versions)
 
     env_tmp = repository_ctx.os.environ.get("TMP", repository_ctx.os.environ.get("TEMP", None))
     if env_tmp != None:
@@ -275,6 +394,7 @@ def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
     compiler_files_line = "compiler_files = " + repr(compiler_files) + ","
     device_runtime_static_libs_line = "device_runtime_static_libs = " + repr(cuda.device_runtime_static_libs_labels) + ","
 
+    select_versions = _versions_to_select_on(repository_ctx.attr.toolkit_versions)
     substitutions = {
         "# %{compiler_attribute_line}": compiler_attr_line,
         "# %{compiler_files_line}": compiler_files_line,
@@ -283,7 +403,12 @@ def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
         "%{clang_label}": clang_label_for_subst,  # Will be empty if path is used
         "%{cuda_path}": cuda_path_for_subst,
         "# %{path_data_line}": path_data_line,
-        "%{cuda_version}": "{}.{}".format(cuda.version_major, cuda.version_minor),
+        "# %{cuda_version_line}": _version_select(
+            "version",
+            select_versions,
+            lambda v: '"{}.{}"'.format(*_major_minor(v)),
+            '"{}.{}"'.format(cuda.version_major, cuda.version_minor),
+        ),
         "%{nvcc_label}": cuda.nvcc_label,
         "%{nvlink_label}": cuda.nvlink_label,
         "%{link_stub_label}": cuda.link_stub_label,
@@ -295,6 +420,7 @@ def _generate_toolchain_clang_build(repository_ctx, cuda, clang_path_or_label):
         substitutions["# %{cicc_line}"] = "cicc = " + repr(cuda.cicc_label)
     if cuda.libdevice_label:
         substitutions["# %{libdevice_line}"] = "libdevice = " + repr(cuda.libdevice_label)
+    _substitute_version_config_settings(substitutions, select_versions)
 
     if clang_label_for_subst:
         substitutions.pop("%{clang_path}")

--- a/cuda/private/templates/BUILD.toolchain_clang
+++ b/cuda/private/templates/BUILD.toolchain_clang
@@ -7,6 +7,8 @@ load(
     cuda_toolchain_config = "cuda_toolchain_config_clang",
 )
 
+# %{toolkit_version_config_settings}
+
 cuda_toolkit_info(
     name = "cuda-toolkit",
     bin2c = "%{bin2c_label}",
@@ -19,7 +21,7 @@ cuda_toolkit_info(
     path = "%{cuda_path}",
     ptxas = "%{ptxas_label}",
     # %{path_data_line}
-    version = "%{cuda_version}",
+    # %{cuda_version_line}
 )
 
 cuda_toolchain_config(

--- a/cuda/private/templates/BUILD.toolchain_nvcc
+++ b/cuda/private/templates/BUILD.toolchain_nvcc
@@ -7,6 +7,8 @@ load(
     cuda_toolchain_config = "cuda_toolchain_config_nvcc",
 )
 
+# %{toolkit_version_config_settings}
+
 cuda_toolkit_info(
     name = "cuda-toolkit",
     bin2c = "%{bin2c_label}",
@@ -18,15 +20,14 @@ cuda_toolkit_info(
     # %{device_runtime_static_libs_line}
     path = "%{cuda_path}",
     ptxas = "%{ptxas_label}",
-    version = "%{cuda_version}",
+    # %{cuda_version_line}
 )
 
 cuda_toolchain_config(
     name = "nvcc-local-config",
     cuda_toolkit = ":cuda-toolkit",
-    # int("%{foo}") instead of %{foo} to make the file valid syntactically.
-    nvcc_version_major = int("%{nvcc_version_major}"),
-    nvcc_version_minor = int("%{nvcc_version_minor}"),
+    # %{nvcc_version_major_line}
+    # %{nvcc_version_minor_line}
     toolchain_identifier = "nvcc",
 )
 

--- a/cuda/private/templates/BUILD.toolchain_nvcc_msvc
+++ b/cuda/private/templates/BUILD.toolchain_nvcc_msvc
@@ -7,6 +7,8 @@ load(
     cuda_toolchain_config = "cuda_toolchain_config_nvcc_msvc",
 )
 
+# %{toolkit_version_config_settings}
+
 cuda_toolkit_info(
     name = "cuda-toolkit",
     bin2c = "%{bin2c_label}",
@@ -18,16 +20,15 @@ cuda_toolkit_info(
     # %{device_runtime_static_libs_line}
     path = "%{cuda_path}",
     ptxas = "%{ptxas_label}",
-    version = "%{cuda_version}",
+    # %{cuda_version_line}
 )
 
 cuda_toolchain_config(
     name = "nvcc-local-config",
     cuda_toolkit = ":cuda-toolkit",
     msvc_env_tmp = "%{env_tmp}",
-    # int("%{foo}") instead of %{foo} to make the file valid syntactically.
-    nvcc_version_major = int("%{nvcc_version_major}"),
-    nvcc_version_minor = int("%{nvcc_version_minor}"),
+    # %{nvcc_version_major_line}
+    # %{nvcc_version_minor_line}
     toolchain_identifier = "nvcc",
 )
 

--- a/tests/integration/test_all.sh
+++ b/tests/integration/test_all.sh
@@ -11,6 +11,7 @@ skip_components_bzlmod=false
 skip_redist_json=false
 skip_redist_json_multi=false
 skip_redist_json_collision=false
+skip_redist_json_version_gate=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -32,6 +33,8 @@ while [[ $# -gt 0 ]]; do
             skip_redist_json_multi=true; shift ;;
         --no-redist-collision)
             skip_redist_json_collision=true; shift ;;
+        --no-redist-version-gate)
+            skip_redist_json_version_gate=true; shift ;;
         *)
             echo "Unknown option: $1" >&2; shift ;;
     esac
@@ -212,6 +215,35 @@ pushd "$this_dir/toolchain_redist_json_multi"
     # Keep the override-only dedupe probe isolated so it cannot pollute later versioned builds.
     bazel clean && bazel shutdown
     CUDA_REDIST_VERSION_OVERRIDE=11.7.0 bazel build --enable_bzlmod //:optionally_use_rule --@rules_cuda//cuda:enable=False "${redist_platform_args[@]}"
+    bazel clean && bazel shutdown
+popd
+fi
+
+# Compiling against the LOWER of two declared versions, where the two straddle a
+# version-gated nvcc flag. The toolchain used to report the maximum declared version
+# regardless of which nvcc the component aliases resolved to, so a 12.x compile was
+# handed a 12.9+-only flag and nvcc rejected it.
+#
+# Two things are pinned rather than inherited from the environment, because both would
+# otherwise stop this testing what it is here to test:
+#
+#   - CUDA_REDIST_VERSION_OVERRIDE is unset. CI exports it for the whole script, and it
+#     rewrites the version of EVERY redist_json, collapsing both declarations onto one
+#     version.
+#   - The compiler is pinned to nvcc. The flag under test is an nvcc flag, and clang
+#     brings its own version coupling: it targets a PTX ISA its own release chose, which
+#     the older toolkit's ptxas then rejects ("Unsupported .version 8.8").
+if [ "$skip_redist_json_version_gate" = false ]; then
+cat <<- EOF
+
+============================================================
+=== TEST: TOOLCHAIN WITH REDISTRIB.JSON (BZLMOD VERSION GATE)
+============================================================
+EOF
+pushd "$this_dir/toolchain_redist_json_version_gate"
+    version_gate_args=(--@rules_cuda//cuda:compiler=nvcc "${redist_platform_args[@]}")
+    env -u CUDA_REDIST_VERSION_OVERRIDE bazel build --enable_bzlmod //:kernel_lib --@rules_cuda//cuda:version=12.9.1 "${version_gate_args[@]}"
+    env -u CUDA_REDIST_VERSION_OVERRIDE bazel build --enable_bzlmod //:kernel_lib --@rules_cuda//cuda:version=12.8.1 "${version_gate_args[@]}"
     bazel clean && bazel shutdown
 popd
 fi

--- a/tests/integration/toolchain_redist_json_version_gate/BUILD.bazel
+++ b/tests/integration/toolchain_redist_json_version_gate/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@rules_cuda//cuda:defs.bzl", "cuda_library")
+
+write_file(
+    name = "kernel",
+    out = "kernel.cu",
+    content = ["__global__ void noop() {}"],
+)
+
+# Built once per declared CUDA version. The flags nvcc is invoked with are gated on the
+# toolchain's reported version, so building this against the version whose nvcc lacks a
+# gated flag is what catches the toolchain reporting a different version than it runs.
+cuda_library(
+    name = "kernel_lib",
+    srcs = [":kernel"],
+    tags = ["manual"],
+    deps = ["@cuda//:cuda_runtime"],
+)

--- a/tests/integration/toolchain_redist_json_version_gate/MODULE.bazel
+++ b/tests/integration/toolchain_redist_json_version_gate/MODULE.bazel
@@ -1,0 +1,37 @@
+module(name = "bzlmod_redist_json_version_gate")
+
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "rules_cc", version = "0.2.14")
+bazel_dep(name = "rules_cuda", version = "0.0.0")
+local_path_override(
+    module_name = "rules_cuda",
+    path = "../../..",
+)
+
+# Two versions straddling a version-gated nvcc flag, so that building against the LOWER
+# one proves the toolchain reports the version whose nvcc actually runs. 12.9 is where
+# `--frandom-seed` appears (see nvcc_fixed_random_seed in cuda/private/toolchain_configs),
+# so 12.9.1 has it and 12.8.1 does not.
+#
+# Both are CUDA 12, deliberately: the pair only has to straddle the flag gate, and staying
+# on one major keeps the components identical between them, so this tests the version the
+# toolchain reports and nothing else.
+cuda = use_extension("@rules_cuda//cuda:extensions.bzl", "toolchain")
+cuda.redist_json(
+    name = "cuda_12_9_1",
+    platforms = [
+        "linux-x86_64",
+        "windows-x86_64",
+    ],
+    version = "12.9.1",
+)
+cuda.redist_json(
+    name = "cuda_12_8_1",
+    platforms = [
+        "linux-x86_64",
+        "windows-x86_64",
+    ],
+    version = "12.8.1",
+)
+cuda.toolkit(name = "cuda")
+use_repo(cuda, "cuda")


### PR DESCRIPTION
Fixes #477.

## Problem

With several `cuda.redist_json` declared, the component aliases resolve through `--@rules_cuda//cuda:version`, but the generated toolchain hardcodes the **maximum** declared version:

```starlark
# Always use the maximum version so the toolkit includes all components.
toolkit_version = sorted(redist_versions, key = _version_sort_key)[-1]
```

Version-gated behaviour is then decided for a version other than the nvcc that actually runs. Declaring 13.0.2 and 12.8.1 and building at 12.8.1 gets `--frandom-seed`, which is guarded by `nvcc_version_ge(ctx, 12, 9)` and read 13.0 from the stamped attributes:

```
nvcc fatal   : Unknown option '--frandom-seed=bazel-out/k8-fastbuild/bin/_objs/kernel_lib/kernel.pic.o'
```

## Fix

`version`, `nvcc_version_major` and `nvcc_version_minor` now `select()` on `cuda:version`, mirroring what `platform_alias_repo` already does for the component labels.

The selects are generated in the BUILD templates rather than passed through Starlark, because `cuda_toolkit_info.version` is a string attribute while `nvcc_version_major`/`_minor` are ints, so there is no single value to hand down.

**`cuda_toolkit_info.version` is included deliberately, not just the nvcc attributes.** It becomes `CudaToolkitInfo.version_major`, which picks `--image3` over `--image` for CUDA >= 13 in `dlink.bzl`. Fixing only the nvcc attributes would leave a 12.x build under a 13.x maximum device-linking with CUDA 13 syntax.

`//conditions:default` keeps the maximum declared version, matching what the component aliases already resolve to when `cuda:version` is unset.

## Single-version output is unchanged

No `config_setting` and no `select` are emitted for a single declared version. Diffing the generated `@cuda//toolchain/BUILD` for `tests/integration/toolchain_redist_json` before and after, the only change is the literals no longer needing the string-substitution workaround:

```diff
-    # int("%{foo}") instead of %{foo} to make the file valid syntactically.
-    nvcc_version_major = int("12"),
-    nvcc_version_minor = int("6"),
+    nvcc_version_major = 12,
+    nvcc_version_minor = 6,
```

## Test

`tests/integration/toolchain_redist_json_multi` declares 11.7.0 and 12.6.3, both below the 12.9 gate, so no version-gated flag differs between them and this cannot surface there. The new `toolchain_redist_json_version_gate` case declares 13.0.2 and 12.8.1, which straddle that gate, and compiles a `cuda_library` against each.

Two things worth flagging about it:

- **It must not run with `CUDA_REDIST_VERSION_OVERRIDE` set.** CI exports it for the whole script, and it rewrites the version of *every* `redist_json`, collapsing both declarations onto one version and leaving nothing multi-version to test. The case unsets it for its own builds, so it stays meaningful under the existing CI invocation. This is also why the existing multi-version case degenerates to single-version in CI today.
- `crt` and `nvvm` are requested only from 13.0.2, since they are required from CUDA 13 on and are not published before it.

## Verification

On this branch, `--@rules_cuda//cuda:version` now drives both the nvcc that runs and the flags it is given:

| `cuda:version` | nvcc invoked | `--frandom-seed` |
| --- | --- | --- |
| 13.0.2 | `cuda_nvcc_linux_x86_64_13_0_2` | present |
| 12.8.1 | `cuda_nvcc_linux_x86_64_12_8_1` | absent |

Both `cuda_library` builds succeed; on `main` the 12.8.1 one fails with the error above.

Also run locally:

- `bazel test //tests/...` — 58 pass, 6 skipped
- `examples`: `//basic:all //rdc:all //if_cuda:main` — including the `rdc` device-link path that exercises the `version_major` gate
- `tests/integration/test_all.sh` for the cases this machine can run (root, none, collision, redist_json, and the new case) — exit 0
- `pre-commit run --all-files` — buildifier and prettier pass; commitizen passes on both commit messages

Two integration builds could not run here for environmental reasons unrelated to this change: CUDA 11.7 does not accept this host's gcc 13 / glibc headers (`identifier "_Float32" is undefined`), which reproduces identically on unpatched `main`. The 12.6.3 half of that case passes.

I have also run this against a real repository that declares CUDA 12.8.1 and 13.2.2 side by side and builds torch CUDA extensions against both. It previously needed `cuda_features = ["-nvcc_fixed_random_seed"]` on every 12.8 target; with this change that workaround is removable, each dependency set resolves its own nvcc, and the flag is applied only where the nvcc supports it.

## Note on the patch in #477

The reporter attached a patch and noted it was AI-generated with some slop in it. I wrote this independently and did not carry that patch over; the two agree on the overall approach, which seemed like the natural fix. Credit for the diagnosis is theirs.
