### PR TITLE
fix: pin MSVC 14.44 on windows-2025 for nvcc host compatibility

### DIFF
--- a/.github/actions/Set-VSEnv.ps1
+++ b/.github/actions/Set-VSEnv.ps1
@@ -1,9 +1,14 @@
 param (
     [parameter(Mandatory = $false)]
-    [ValidateSet(2022, 2019, 2017)][int]$Version = 2019,
+    [ValidateSet(2026, 2022, 2019, 2017)][int]$Version = 2019,
 
     [parameter(Mandatory = $false)]
-    [ValidateSet("all", "x86", "x64")][String]$Arch = "x64"
+    [ValidateSet("all", "x86", "x64")][String]$Arch = "x64",
+
+    # Optional MSVC toolset major.minor (e.g. "14.44") passed to vcvars as -vcvars_ver.
+    # Required on VS 2026 images where the default toolset is too new for nvcc.
+    [parameter(Mandatory = $false)]
+    [string]$ToolsetVersion = ""
 )
 
 function Set-EnvFromCmdSet {
@@ -22,9 +27,27 @@ function Set-EnvFromCmdSet {
     }
 }
 
+function Write-GithubEnvFile {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    if (-not $env:GITHUB_ENV) {
+        return
+    }
+    $value = [System.Environment]::GetEnvironmentVariable($Name)
+    if ($null -eq $value -or $value -eq "") {
+        return
+    }
+    "${Name}=${value}" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+}
+
 $vs_where = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'
 
 $version_range = switch ($Version) {
+    2026 { '[18,19)' }
     2022 { '[17,18)' }
     2019 { '[16,17)' }
     2017 { '[15,16)' }
@@ -39,11 +62,17 @@ $vs_env = @{
 
 if ( $null -eq $vs_env.install_path) {
     Write-Host -ForegroundColor Red "Visual Studio $Version is not installed."
-    return
+    exit 1
 }
 
 $path = Join-Path $vs_env.install_path $vs_env.$Arch
+$vcvars_arg = if ($ToolsetVersion) { " -vcvars_ver=$ToolsetVersion" } else { "" }
 
-C:/Windows/System32/cmd.exe /c "`"$path`" & set" | Set-EnvFromCmdSet
+C:/Windows/System32/cmd.exe /c "`"$path`"$vcvars_arg & set" | Set-EnvFromCmdSet
 Set-Item -Force -Path "Env:\BAZEL_VC" -Value "$env:VCINSTALLDIR"
-Write-Host -ForegroundColor Green "Visual Studio $Version $Arch Command Prompt variables set."
+if ($env:VCToolsVersion) {
+    Set-Item -Force -Path "Env:\BAZEL_VC_FULL_VERSION" -Value "$env:VCToolsVersion"
+}
+Write-GithubEnvFile -Name "BAZEL_VC"
+Write-GithubEnvFile -Name "BAZEL_VC_FULL_VERSION"
+Write-Host -ForegroundColor Green "Visual Studio $Version $Arch Command Prompt variables set (MSVC $env:VCToolsVersion)."

--- a/.github/actions/set-build-env/action.yaml
+++ b/.github/actions/set-build-env/action.yaml
@@ -80,4 +80,13 @@ runs:
     - name: Set Visual Studio Environment (Windows)
       if: ${{ startsWith(inputs.os, 'windows') }}
       shell: pwsh
-      run: .github/actions/Set-VSEnv.ps1 2019
+      # windows-2025: VS 2026 default toolset is MSVC 14.51 (unsupported by nvcc).
+      # Pin the side-by-side 14.44 toolset and persist BAZEL_VC* via GITHUB_ENV.
+      # windows-2022: VS 2022 already defaults to a 14.4x toolset nvcc accepts.
+      run: |
+        if ("${{ inputs.os }}" -like "windows-2025*") {
+          .github/actions/Set-VSEnv.ps1 2026 -ToolsetVersion 14.44
+        } else {
+          .github/actions/Set-VSEnv.ps1 2022
+        }
+

--- a/.github/actions/set-build-env/action.yaml
+++ b/.github/actions/set-build-env/action.yaml
@@ -89,4 +89,3 @@ runs:
         } else {
           .github/actions/Set-VSEnv.ps1 2022
         }
-


### PR DESCRIPTION
windows-2025 runners ship VS 2026 with default MSVC 14.51, which nvcc cannot parse.

Select VS 2026 + toolset 14.44 (VS 2022 on older images), set BAZEL_VC / BAZEL_VC_FULL_VERSION from vcvars, and persist them via GITHUB_ENV so later bazelisk steps keep the pin.