### PR TITLE
Place obj file in seperate dir

### DIFF
--- a/cuda/private/actions/compile.bzl
+++ b/cuda/private/actions/compile.bzl
@@ -63,13 +63,21 @@ def compile(
         filename = None
         filename = cuda_helper.get_artifact_name(cuda_toolchain, artifact_category_name, basename)
 
-        # Objects are placed in <_prefix>/<tgt_name>/<filename>.
+        # Keep action output variants in separate directories because NVCC may place 
+        # temporary files beside the output object, see 
+        # https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#objdir-as-tempdir-objtemp
+        # ... same file is compiled with different options ...
+        # Compiling them in the same directory can either cause the compilation to fail or produce incorrect results.
+        #
+        # Objects are placed in <_prefix>/<tgt_name>/<artifact_category>/<filename>.
         # For files with the same basename, say srcs = ["kernel.cu", "foo/kernel.cu", "bar/kernel.cu"], we get
-        # <_prefix>/<tgt_name>/0/kernel.<ext>, <_prefix>/<tgt_name>/1/kernel.<ext>, <_prefix>/<tgt_name>/2/kernel.<ext>.
+        # <_prefix>/<tgt_name>/object_file/0/kernel.<ext>,
+        # <_prefix>/<tgt_name>/pic_object_file/0/kernel.<ext>,
+        # <_prefix>/<tgt_name>/pic_object_file/1/kernel.<ext>.
         # Otherwise, the index is not presented.
         if basename_counter[basename] > 1:
             filename = "{}/{}".format(basename_index, filename)
-        obj_file = actions.declare_file("{}/{}/{}".format(_prefix, ctx.attr.name, filename))
+        obj_file = actions.declare_file("{}/{}/{}/{}".format(_prefix, ctx.attr.name, artifact_category_name, filename))
         ret.append(obj_file)
 
         var = cuda_helper.create_compile_variables(

--- a/tests/flag/BUILD.bazel
+++ b/tests/flag/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cuda//cuda:defs.bzl", "cuda_library")
+load(":compile_output_test.bzl", "cuda_compile_output_directory_test")
 load(
     ":flag_validation_test.bzl",
     "cuda_library_c_dbg_flag_test",
@@ -31,6 +32,11 @@ num_actions_test(
     target_under_test = "@rules_cuda_examples//basic:kernel",
     # 2 compiling, 2 lib, non-pic and pic respectively
     # num_actions = 4,
+)
+
+cuda_compile_output_directory_test(
+    name = "cuda_library_compile_output_directory_test",
+    target_under_test = "@rules_cuda_examples//basic:kernel",
 )
 
 cuda_library_flag_test(
@@ -224,6 +230,11 @@ cuda_library(
     host_copts = ["-O1"],
     rdc = 1,
     tags = ["manual"],
+)
+
+cuda_compile_output_directory_test(
+    name = "cuda_library_rdc_compile_output_directory_test",
+    target_under_test = "examples_basic_kernel_with_flags",
 )
 
 cuda_library_flag_test(

--- a/tests/flag/compile_output_test.bzl
+++ b/tests/flag/compile_output_test.bzl
@@ -1,0 +1,32 @@
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+def _cuda_compile_output_directory_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    actions = analysistest.target_actions(env)
+    outputs_by_directory = {}
+    output_count = 0
+
+    for action in actions:
+        if action.mnemonic != "CudaCompile":
+            continue
+        for output in action.outputs.to_list():
+            previous_output = outputs_by_directory.get(output.dirname)
+            asserts.equals(
+                env,
+                None,
+                previous_output,
+                "CudaCompile outputs '{}' and '{}' share directory '{}'".format(
+                    previous_output,
+                    output.path,
+                    output.dirname,
+                ),
+            )
+            outputs_by_directory[output.dirname] = output.path
+            output_count += 1
+
+    asserts.equals(env, 2, output_count)
+    return analysistest.end(env)
+
+cuda_compile_output_directory_test = analysistest.make(
+    _cuda_compile_output_directory_test_impl,
+)


### PR DESCRIPTION
without --objdir-as-tempdir,  nvcc will put temp cpp file under shared /tmp directory, while multi compile running in parallel, they create non-deterministic file. using 
```bash
llvm-nm -a cuda_library.a |grep tmp
```
it might shows 
`tmpxft_00000002_00000000-6_kernel.cudafe1.cpp` or 
`tmpxft_00000002_00000001-6_kernel.cudafe1.cpp`

apply [--objdir-as-tempdir](https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#objdir-as-tempdir-objtemp) arguments fix this by place stable file under object directory ,  it explicitly declared same file compiled with different options shouldn't be in same directory. rules_cuda now placed object file and pic object file under same directory, which might break --objdir-as-tempdir.

this PR address this by place output under different category folder.

Note: test is written by codex, revert place-file-under-category commit confirms the test failed as expected.