### PR TITLE
Forward `--copt/--cxxopt` into the CUDA host-compile flags

### DIFF
--- a/cuda/private/cuda_helper.bzl
+++ b/cuda/private/cuda_helper.bzl
@@ -282,7 +282,7 @@ def _get_cc_host_compile_flags(ctx):
     variables = cc_common.create_compile_variables(
         cc_toolchain = cc_toolchain,
         feature_configuration = feature_configuration,
-        user_compile_flags = [],
+        user_compile_flags = user_flags,
         source_file = dummy_src,
         output_file = dummy_out,
     )


### PR DESCRIPTION
`_get_cc_host_compile_flags()` simulates a plain `cpp_compile` action against the registered `cc_toolchain` to discover its default flags, but passes `user_compile_flags = []` and separately computes (and never uses) the target's actual `--copt/--cxxopt` values in user_flags. This means any warning flags applied repo-wide via `--copt/--host_copt` (e.g. a blanket `-Wno-everything`) never reach the host side of a `.cu` compile, while the toolchain's own default warning flags still do, since both are forwarded together via `-Xcompiler` through the always-on `cuda_host_use_toolchain_flags` feature. 

Pass the already-computed `user_flags` through so the two stay consistent with how a normal `cc_library/cc_binary` compile already behaves.