### PR TITLE
fix: resolve CCCL headers from the CUDA 13 include path

### DIFF
--- a/cuda/private/template_helper.bzl
+++ b/cuda/private/template_helper.bzl
@@ -149,10 +149,19 @@ def _expand_dctk_cuda(repository_ctx, components):
     }
     return _expand_template(repository_ctx, tpl_label, substitutions = substitutions)
 
+# Components whose own fragment declares `<component>_headers`, so BUILD.dctk_comp must
+# not: both fragments land in one BUILD file, and only one may declare a given target.
+# cccl does, because CUDA 13 moved its headers into an `include/cccl/` subdirectory and
+# only its fragment knows to follow that.
+_COMPONENTS_DECLARING_OWN_HEADERS = ["cccl"]
+
 def _expand_dctk_component(repository_ctx, component):
     tpl_label = Label("//cuda/private:templates/BUILD.dctk_comp")
     substitutions = {
         "%{component_name}": component,
+        "%{dctk_comp_generic_headers}": repr(
+            [] if component in _COMPONENTS_DECLARING_OWN_HEADERS else [None],
+        ),
     }
     return _expand_template(repository_ctx, tpl_label, substitutions = substitutions)
 

--- a/cuda/private/templates/BUILD.cccl
+++ b/cuda/private/templates/BUILD.cccl
@@ -55,3 +55,27 @@ cc_library(
     ),
     deps = [":cub"],
 )
+
+# The version-aware `cccl_headers`, replacing the generic one from BUILD.dctk_comp, which
+# always points at `include/`. CUDA 13 moved the CCCL headers into `include/cccl/`, so the
+# generic path resolves `<cccl/thrust/...>` rather than `<thrust/...>`.
+#
+# Deliverable repos only: there, the generic target is suppressed for this component (see
+# template_helper.bzl) and this one takes its place. A local toolkit expands this fragment
+# into @cuda itself, where `%{component_name}` is "cuda" and BUILD.lctk_cuda already owns
+# `cuda_headers`.
+[
+    cc_library(
+        name = "%{component_name}_headers",
+        hdrs = glob(
+            ["%{component_name}/include/**"],
+            allow_empty = True,
+        ),
+        includes = if_cuda_toolkit_version_ge(
+            (13, 0),
+            ["%{component_name}/include/cccl"],
+            ["%{component_name}/include"],
+        ),
+    )
+    for _ in if_local_cuda_toolkit([], [None])
+]

--- a/cuda/private/templates/BUILD.dctk_comp
+++ b/cuda/private/templates/BUILD.dctk_comp
@@ -21,8 +21,13 @@ filegroup(
     visibility = ["//visibility:private"],
 )
 
-cc_library(
-    name = "%{component_name}_headers",
-    hdrs = [":%{component_name}_header_files"],
-    includes = ["%{component_name}/include"],
-)
+# Suppressed for components whose own fragment declares this target instead, since both
+# fragments land in one BUILD file and only one may declare it. See template_helper.bzl.
+[
+    cc_library(
+        name = "%{component_name}_headers",
+        hdrs = [":%{component_name}_header_files"],
+        includes = ["%{component_name}/include"],
+    )
+    for _ in %{dctk_comp_generic_headers}
+]

--- a/tests/integration/test_all.sh
+++ b/tests/integration/test_all.sh
@@ -12,6 +12,7 @@ skip_redist_json=false
 skip_redist_json_multi=false
 skip_redist_json_collision=false
 skip_redist_json_version_gate=false
+skip_cccl_headers=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -35,6 +36,8 @@ while [[ $# -gt 0 ]]; do
             skip_redist_json_collision=true; shift ;;
         --no-redist-version-gate)
             skip_redist_json_version_gate=true; shift ;;
+        --no-cccl-headers)
+            skip_cccl_headers=true; shift ;;
         *)
             echo "Unknown option: $1" >&2; shift ;;
     esac
@@ -244,6 +247,24 @@ pushd "$this_dir/toolchain_redist_json_version_gate"
     version_gate_args=(--@rules_cuda//cuda:compiler=nvcc "${redist_platform_args[@]}")
     env -u CUDA_REDIST_VERSION_OVERRIDE bazel build --enable_bzlmod //:kernel_lib --@rules_cuda//cuda:version=12.9.1 "${version_gate_args[@]}"
     env -u CUDA_REDIST_VERSION_OVERRIDE bazel build --enable_bzlmod //:kernel_lib --@rules_cuda//cuda:version=12.8.1 "${version_gate_args[@]}"
+    bazel clean && bazel shutdown
+popd
+fi
+
+# `<thrust/...>` resolving through the header-only targets. CUDA 13 moved the CCCL headers
+# into `include/cccl/`, so a version-unaware `includes` resolves `<cccl/thrust/...>` and
+# these stop compiling. One declared version, so CUDA_REDIST_VERSION_OVERRIDE sweeps this
+# across the CUDA versions in the CI matrix and covers both layouts.
+if [ "$skip_cccl_headers" = false ]; then
+cat <<- EOF
+
+============================================================
+=== TEST: CCCL HEADER-ONLY TARGETS (BZLMOD)
+============================================================
+EOF
+pushd "$this_dir/toolchain_cccl_headers"
+    bazel build --enable_bzlmod //:via_cccl_headers "${redist_platform_args[@]}"
+    bazel build --enable_bzlmod //:via_cuda_headers "${redist_platform_args[@]}"
     bazel clean && bazel shutdown
 popd
 fi

--- a/tests/integration/toolchain_cccl_headers/BUILD.bazel
+++ b/tests/integration/toolchain_cccl_headers/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@rules_cuda//cuda:defs.bzl", "cuda_library")
+
+# thrust refuses to compile below C++17 ("Thrust requires at least C++17"), and some CI
+# hosts default to an older standard. This is nvcc's own `-std`, not `-Xcompiler`, so that
+# it governs the device dialect as well as the host pass -- passing only a host flag leaves
+# nvcc compiling the CCCL headers as C++14.
+_COPTS = ["-std=c++17"]
+
+# Through the cccl component's own headers target.
+cuda_library(
+    name = "via_cccl_headers",
+    srcs = ["kernel.cu"],
+    copts = _COPTS,
+    tags = ["manual"],
+    deps = ["@cuda//:cccl_headers"],
+)
+
+# And through the aggregate that wraps every component's headers, which is how most
+# consumers reach them.
+cuda_library(
+    name = "via_cuda_headers",
+    srcs = ["kernel.cu"],
+    copts = _COPTS,
+    tags = ["manual"],
+    deps = ["@cuda//:cuda_headers"],
+)

--- a/tests/integration/toolchain_cccl_headers/MODULE.bazel
+++ b/tests/integration/toolchain_cccl_headers/MODULE.bazel
@@ -1,0 +1,25 @@
+module(name = "bzlmod_cccl_headers")
+
+bazel_dep(name = "rules_cc", version = "0.2.14")
+bazel_dep(name = "rules_cuda", version = "0.0.0")
+local_path_override(
+    module_name = "rules_cuda",
+    path = "../../..",
+)
+
+# ONE version, deliberately: CI overrides it via CUDA_REDIST_VERSION_OVERRIDE, so this case
+# runs against whichever CUDA the job installed and covers both header layouts across the
+# matrix. Declaring two versions here would instead exercise the multi-version toolkit,
+# where `if_cuda_toolkit_version_ge` reads the maximum declared version rather than the
+# selected one -- a separate problem, and not what this is testing.
+cuda = use_extension("@rules_cuda//cuda:extensions.bzl", "toolchain")
+cuda.redist_json(
+    name = "cuda_redist",
+    platforms = [
+        "linux-x86_64",
+        "windows-x86_64",
+    ],
+    version = "13.0.2",
+)
+cuda.toolkit(name = "cuda")
+use_repo(cuda, "cuda")

--- a/tests/integration/toolchain_cccl_headers/kernel.cu
+++ b/tests/integration/toolchain_cccl_headers/kernel.cu
@@ -1,0 +1,6 @@
+// `<thrust/...>` has to resolve through the header-only targets. CUDA 13 moved the CCCL
+// headers into `include/cccl/`, so an `includes` pointing at `include/` resolves
+// `<cccl/thrust/...>` and this stops compiling.
+#include <thrust/complex.h>
+
+__global__ void probe() {}


### PR DESCRIPTION
Fixes #489.

## Problem

`cccl_headers` is generated from the generic `<component>_headers` in `BUILD.dctk_comp`, which always sets `includes` to `<component>/include`. CUDA 13 moved the CCCL headers one level deeper, into `include/cccl/`, so that path resolves `<cccl/thrust/...>` but not `<thrust/...>`:

```
fatal error: thrust/complex.h: No such file or directory
```

The per-library targets in `BUILD.cccl` already handle the move, but `cccl_headers` is not generated from that fragment. It also reaches `cuda_headers`, which aggregates every component's headers target, so both fail the same way.

## Fix

Per your suggestion in the issue: `BUILD.cccl` now declares `cccl_headers` itself, using the same `if_cuda_toolkit_version_ge` as the neighbouring `thrust`/`cub`/`libcudacxx` targets, and the generic target in `BUILD.dctk_comp` is suppressed for that component. The two fragments are concatenated into one BUILD file, so only one of them may declare it — the suppression is required, not cosmetic. It follows the shape of `_component_owns_cuda_repo_alias` from #488.

Keeping the version knowledge in the fragment that already has it avoids teaching the generic template about CCCL's layout.

One wrinkle worth flagging: the new target is confined to deliverable repos via `if_local_cuda_toolkit`. A local toolkit expands `BUILD.cccl` into `@cuda` itself, where `%{component_name}` is `cuda` and `BUILD.lctk_cuda` already declares `cuda_headers` — without the guard, `toolchain_root` fails with a duplicate `cuda_headers`.

## Verification

Non-cccl component repos generate byte-identical BUILD files, and exactly one `cccl_headers` is declared:

| Toolkit | `cccl_headers` resolves to |
| --- | --- |
| CUDA 13.0.2 | `cccl/include/cccl` |
| CUDA 12.8.1 | `cccl/include` |

The new integration case builds a kernel including `<thrust/complex.h>` through both `cccl_headers` and the `cuda_headers` aggregate. It declares a single CUDA version, so `CUDA_REDIST_VERSION_OVERRIDE` sweeps it across the versions in the matrix and covers both layouts. I confirmed it fails on unpatched main and passes here.

The targets pass nvcc's own `-std=c++17`, not an `-Xcompiler` host flag: thrust refuses to compile below C++17, some CI hosts default lower, and a host-only flag leaves nvcc compiling the CCCL headers as C++14 (which fails on MSVC with "inline specifier allowed on function declarations only").

Full matrix green on a branch in my fork — all 10 `Test Example Build` jobs including the three Windows ones, plus `Test Utilities` and `pre-commit`. Also ran `bazel test //tests/...` (82 pass), the examples including `//rdc:all`, and `test_all.sh`.

## Separate, not fixed here

While testing this across two declared versions I hit a different instance of the max-version problem: every component repo loads `@cuda//:defs.bzl`, whose `ctk_version` is stamped from the maximum declared version, so `if_cuda_toolkit_version_ge` returns the wrong answer inside a non-maximum component repo. On current main, `@cuda_cccl_..._12_8_1//:thrust` already resolves `cccl/include/cccl` when 13.x is also declared.

That is pre-existing and affects `thrust`, `cub` and `libcudacxx` equally, and it cannot be fixed in the fragments, since `if_cuda_toolkit_version_ge` is a load-time function reading a stamped constant. It needs each component repo to know its own version, which the `version` attribute already carries. I kept it out of this PR and will file it separately unless you would rather it were folded in.
